### PR TITLE
Clarify which shell is needed to avoid portability issues

### DIFF
--- a/create-ami.sh
+++ b/create-ami.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # argument parsing
 if [ "$1" = "--dry-run" ]; then


### PR DESCRIPTION
I run into some issues while running create-ami.sh because the script doesn't specify which shell is compatible, is this a bash script or zsh or something else?
Are you guys running it on Linux or OSX only?
Thanks