### PR TITLE
Add networking option for starting the docker container with different network settings

### DIFF
--- a/runtime/opt/zalando/runtime/Docker
+++ b/runtime/opt/zalando/runtime/Docker
@@ -74,6 +74,9 @@ def get_other_options(config: dict):
     if config.get('hostname'):
         yield '--hostname={}'.format(config.get('hostname'))
 
+    if config.get('networking'):
+        yield '--hostname={}'.format(config.get('networking'))
+
 
 def extract_registry(docker_image: str) -> str:
     """


### PR DESCRIPTION
Add networking option for starting the docker container with different network settings

such as to add an option like
--net=host

ref. #48