### PR TITLE
make ssh args configurable

### DIFF
--- a/config-stups-example.sh
+++ b/config-stups-example.sh
@@ -2,6 +2,9 @@
 #TODO generate on the fly and clean up later
 keypair="jdoe"
 
+# The created hosts are ephemeral and their keys useless
+ssh_args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+
 # region
 region="eu-west-1"
 

--- a/create-ami.sh
+++ b/create-ami.sh
@@ -60,9 +60,6 @@ done
 
 echo "IP: $ip"
 
-# The created hosts are ephemeral and their keys useless
-ssh_args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
-
 # wait for server
 while [ true ]; do
     echo "Waiting for server..."


### PR DESCRIPTION
We would like to pass arguments like "-i" to specify a specific ssh key to be used. The most generic and backwards compatible solution was to move ssh_args to config.