### PR TITLE
privileged support added.

### DIFF
--- a/runtime/opt/taupage/runtime/Docker
+++ b/runtime/opt/taupage/runtime/Docker
@@ -74,6 +74,9 @@ def get_other_options(config: dict):
     if config.get('networking'):
         yield '--net={}'.format(config.get('networking'))
 
+    if config.get('privileged'):
+        yield '--privileged'
+
 
 def extract_registry(docker_image: str) -> str:
     """


### PR DESCRIPTION
Now it is possible to run docker with --privileged option if in taupage.yaml the privileged attribute is true.