### PR TITLE
tr complained about illegal byte sequence on my Mac

### DIFF
--- a/volume_testing.sh
+++ b/volume_testing.sh
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 
-RANDOM_SUFFIX=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 4 | head -n 1)
+RANDOM_SUFFIX=$RANDOM$RANDOM$RANDOM
 TEST_ROLE="test-role-$AMI_ID-$RANDOM_SUFFIX"
 TEST_PERMISSIONS="test-permissions-$AMI_ID-$RANDOM_SUFFIX"
 INSTANCE_PROFILE="test-profile-$AMI_ID-$RANDOM_SUFFIX"


### PR DESCRIPTION
And we use /bin/bash if we are not 100% sure that it has to be POSIX sh compatible (Ubuntu uses dash by default)