### PR TITLE
Add support of non-tcp protocols for docker port-mapping

### DIFF
--- a/runtime/opt/taupage/bin/register-in-etcd.py
+++ b/runtime/opt/taupage/bin/register-in-etcd.py
@@ -17,7 +17,7 @@ def get_first(iterable, default=None):
 
 
 def get_health_check_url(config: dict):
-    default_port = get_first(sorted(get_or(config, 'ports', {}).keys())).split('/')[0]  # strip /protocol
+    default_port = get_first(sorted(config.get('ports', {}).keys())).split('/')[0]  # strip /protocol
     health_check_port = config.get('health_check_port', default_port)
     health_check_path = config.get('health_check_path')
 

--- a/runtime/opt/taupage/bin/register-in-etcd.py
+++ b/runtime/opt/taupage/bin/register-in-etcd.py
@@ -17,7 +17,8 @@ def get_first(iterable, default=None):
 
 
 def get_health_check_url(config: dict):
-    health_check_port = config.get('health_check_port', get_first(sorted(config.get('ports', {}).keys())))
+    default_port = get_first(sorted(get_or(config, 'ports', {}).keys())).split('/')[0]  # strip /protocol
+    health_check_port = config.get('health_check_port', default_port)
     health_check_path = config.get('health_check_path')
 
     if not health_check_path:

--- a/runtime/opt/taupage/runtime/Docker.py
+++ b/runtime/opt/taupage/runtime/Docker.py
@@ -128,6 +128,12 @@ def get_volume_options(config: dict):
 
 def get_port_options(config: dict):
     for host_port, container_port in get_or(config, 'ports', {}).items():
+        protocol = None
+        if '/' in host_port:
+            host_port, protocol = host_port.split('/')
+        if protocol and '/' not in container_port:
+            container_port = '{}/{}'.format(container_port, protocol)
+
         yield '-p'
         yield '{}:{}'.format(host_port, container_port)
 
@@ -223,7 +229,8 @@ def get_first(iterable, default=None):
 
 
 def wait_for_health_check(config: dict):
-    health_check_port = config.get('health_check_port', get_first(sorted(get_or(config, 'ports', {}).keys())))
+    default_port = get_first(sorted(get_or(config, 'ports', {}).keys())).split('/')[0]  # strip /protocol
+    health_check_port = config.get('health_check_port', default_port)
     health_check_path = config.get('health_check_path')
     health_check_timeout_seconds = get_or(config, 'health_check_timeout_seconds', 60)
 


### PR DESCRIPTION
Protocol can be specifyed either from the host side or from the docker
side.

ports:
  8301: 8301
  8301/udp: 8301
  8500: 8500
  8600: 8600/udp