### PR TITLE
Removed automatic initialization of devices

### DIFF
--- a/test-userdata.yaml
+++ b/test-userdata.yaml
@@ -44,7 +44,8 @@ volumes:
 mounts:
     /some_volume:
         partition: /dev/md/sampleraid0
-        erase_on_boot: false
+        erase_on_boot: true
         filesystem: ext4
     /other_volume:
         partition: /dev/md/sampleraid1
+        erase_on_boot: true

--- a/volume_testing.sh
+++ b/volume_testing.sh
@@ -49,6 +49,8 @@ EOF
     aws iam add-role-to-instance-profile --instance-profile-name "$INSTANCE_PROFILE" \
         --role-name "$TEST_ROLE"
 
+    aws iam get-instance-profile --instance-profile-name "$INSTANCE_PROFILE" > /dev/null
+
     rm -f "$TRUST_POLICY" "$PERMISSIONS_POLICY"
 }
 


### PR DESCRIPTION
On some corner cases the has_filesystem call could result in undesired initialization of volumes (While waiting for stabilization).
The feature was too risky and this PR suggest this to be explicit
Also made `partition` optional for cases where only host/container folder mapping is wanted