### PR TITLE
Finally terminate instances on failed builds

### DIFF
--- a/create-ami.sh
+++ b/create-ami.sh
@@ -1,4 +1,14 @@
 #!/usr/bin/env bash
+set -e
+
+# finally terminate ec2 instance
+function finally() {
+
+    # delete instance
+    echo "Terminating server..."
+    aws ec2 terminate-instances --region $region --instance-ids $instanceid > /dev/null
+}
+trap finally EXIT
 
 
 # default description (may be overriden by config file)
@@ -210,10 +220,3 @@ else
 
 fi
 
-function finally {
-
-    # delete instance
-    echo "Terminating server..."
-    aws ec2 terminate-instances --region $region --instance-ids $instanceid > /dev/null
-}
-trap finally EXIT

--- a/create-ami.sh
+++ b/create-ami.sh
@@ -143,11 +143,6 @@ while [ true ]; do
     sleep 10
 done
 
-
-# delete instance
-echo "Terminating server..."
-aws ec2 terminate-instances --region $region --instance-ids $instanceid > /dev/null
-
 # run tests
 ./test.sh $CONFIG_FILE $imageid
 
@@ -214,3 +209,11 @@ else
     echo "AMI $ami_name ($imageid) create failed "
 
 fi
+
+function finally {
+
+    # delete instance
+    echo "Terminating server..."
+    aws ec2 terminate-instances --region $region --instance-ids $instanceid > /dev/null
+}
+trap finally EXIT

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,20 @@
 #!/bin/bash
+set -e
+
+# finally cleanup ec2 instance
+function finally() {
+	# clean up aka terminate test server
+	if [ $DRY_RUN = false ]; then
+		echo "Terminating server..."
+		aws ec2 terminate-instances --region $region --instance-ids $instanceid > /dev/null
+		delete_test_volumes
+		delete_profile_for_volume_attachment
+	else
+		echo "Skipping termination of server due to dry run. Instance profile and test volumes were also kept intact!"
+	fi
+    aws ec2 terminate-instances --region $region --instance-ids $instanceid > /dev/null
+}
+trap finally EXIT
 
 
 cd $(dirname $0)
@@ -124,16 +140,3 @@ else
     exit 1
 fi
 
-function finally {
-	# clean up aka terminate test server
-	if [ $DRY_RUN = false ]; then
-		echo "Terminating server..."
-		aws ec2 terminate-instances --region $region --instance-ids $instanceid > /dev/null
-		delete_test_volumes
-		delete_profile_for_volume_attachment
-	else
-		echo "Skipping termination of server due to dry run. Instance profile and test volumes were also kept intact!"
-	fi
-    aws ec2 terminate-instances --region $region --instance-ids $instanceid > /dev/null
-}
-trap finally EXIT

--- a/test.sh
+++ b/test.sh
@@ -116,17 +116,6 @@ while [ true ]; do
     sleep 10
 done
 
-# clean up aka terminate test server
-if [ $DRY_RUN = false ]; then
-    echo "Terminating server..."
-    aws ec2 terminate-instances --region $region --instance-ids $instanceid > /dev/null
-    delete_test_volumes
-    delete_profile_for_volume_attachment
-else
-    echo "Skipping termination of server due to dry run. Instance profile and test volumes were also kept intact!"
-fi
-
-
 if [ $TEST_OK = true ]; then
     echo "TEST SUCCESS: got good response from http"
     exit 0
@@ -134,3 +123,17 @@ else
     echo "TEST FAILED: http did not come up properly"
     exit 1
 fi
+
+function finally {
+	# clean up aka terminate test server
+	if [ $DRY_RUN = false ]; then
+		echo "Terminating server..."
+		aws ec2 terminate-instances --region $region --instance-ids $instanceid > /dev/null
+		delete_test_volumes
+		delete_profile_for_volume_attachment
+	else
+		echo "Skipping termination of server due to dry run. Instance profile and test volumes were also kept intact!"
+	fi
+    aws ec2 terminate-instances --region $region --instance-ids $instanceid > /dev/null
+}
+trap finally EXIT


### PR DESCRIPTION
If anything fails during build or test of the taupage ami, the used ec2 instances remain active. I propose to cleanup finally if anything went wrong. The traps should do the job.