### PR TITLE
Use --create instead of --build mdadm option when creating a new RAID array. 

### DIFF
--- a/runtime/opt/taupage/init.d/10-prepare-disks.py
+++ b/runtime/opt/taupage/init.d/10-prepare-disks.py
@@ -156,7 +156,7 @@ def create_raid_device(raid_device, raid_config):
     else:
         raid_level = raid_config.get("level")
         call = ["mdadm",
-                "--build", raid_device,
+                "--create", raid_device,
                 "--level=" + str(raid_level),
                 "--raid-devices=" + str(num_devices)]
         # Give devices some time to be available in case they were recently attached


### PR DESCRIPTION
Build option should be used only for compatibility with old systems and does not support all levels, in particular, level 10.