### PR TITLE
Use --create with mdadm instead of --build

### DIFF
--- a/runtime/opt/taupage/init.d/10-prepare-disks.py
+++ b/runtime/opt/taupage/init.d/10-prepare-disks.py
@@ -156,6 +156,7 @@ def create_raid_device(raid_device, raid_config):
     else:
         raid_level = raid_config.get("level")
         call = ["mdadm",
+                "--run",
                 "--create", raid_device,
                 "--level=" + str(raid_level),
                 "--raid-devices=" + str(num_devices)]


### PR DESCRIPTION
--create supports creating RAID10 arrays.
Make sure mdam does not complain about older boot loaders by supplying --run option.