### PR TITLE
mount log directory as read-only

### DIFF
--- a/runtime/opt/taupage/runtime/Docker.py
+++ b/runtime/opt/taupage/runtime/Docker.py
@@ -103,9 +103,9 @@ def get_volume_options(config: dict):
     # mount the meta directory as read-only filesystem
     yield '/meta:/meta:ro'
     # mount logdirectory as read-only
-    # Todo: this has to be made optional.
-    # yield '-v'
-    # yield '/var/log:/var/log:ro'
+    if config.get('mount_var_log'):
+        yield '-v'
+        yield '/var/log:/var/log:ro'
 
     # if NewRelic Agent exisits than mount the agent to the docker container
     # TODO move newrelic to /opt/proprietary and mount to /agents/newrelic-jvm


### PR DESCRIPTION
This would be a proposal, which should solve the issue we've had. This lets users optionally use ``mount_var_log`` if it is set to ``true``.
@apfeiffer85 or/and @hjacobs please review.

This should fix https://github.com/zalando-stups/taupage/issues/110