### PR TITLE
daily rotation of application.log to prevent disk overflows

### DIFF
--- a/runtime/etc/logrotate.d/application
+++ b/runtime/etc/logrotate.d/application
@@ -1,0 +1,15 @@
+/var/log/application.log {
+    # do not use datesuffix, aws logs could not deal with
+    su root root
+    missingok
+    notifempty
+    daily
+    create 0640 syslog adm
+    # aws takes a while to switch to new logfile
+    delaycompress
+    compress
+    rotate 7
+    postrotate
+        service rsyslog restart
+    endscript
+}

--- a/runtime/etc/logrotate.d/rsyslog
+++ b/runtime/etc/logrotate.d/rsyslog
@@ -23,7 +23,6 @@
 /var/log/cron.log
 /var/log/debug
 /var/log/messages
-/var/log/application.log
 {
 	rotate 4
 	weekly


### PR DESCRIPTION
We've seen disk overflows on instances existing for multiple days with significant traffic leading to significant amount of logs. To prevent this, we would like to rotate application.log on a daily base.