### PR TITLE
Added mount_certs option

### DIFF
--- a/runtime/opt/taupage/runtime/Docker.py
+++ b/runtime/opt/taupage/runtime/Docker.py
@@ -109,10 +109,16 @@ def get_volume_options(config: dict):
     yield '-v'
     # mount the meta directory as read-only filesystem
     yield '/meta:/meta:ro'
+
     # mount logdirectory as read-only
     if config.get('mount_var_log'):
         yield '-v'
         yield '/var/log:/var/log:ro'
+
+    # mount certs dir as read-only. 'private' is currently empty on Taupage
+    if config.get('mount_certs'):
+        yield '-v'
+        yield '/etc/ssl/certs:/etc/ssl/certs:ro'
 
     # if NewRelic Agent exisits than mount the agent to the docker container
     if 'newrelic_account_key' in config:

--- a/test-userdata.yaml
+++ b/test-userdata.yaml
@@ -28,7 +28,6 @@ healthcheck:
 
 health_check_path: /
 
-
 ssh_ports:
   - 22
   - 2222
@@ -46,9 +45,10 @@ volumes:
         - /dev/xvdb
         - /dev/xvdc
 
-
 mounts:
     /some_volume:
         partition: /dev/md/sampleraid0
         erase_on_boot: true
         filesystem: ext4
+
+mount_certs: true


### PR DESCRIPTION
This adds a new boolean options to taupage config `mount_certs: <true|false>`

This options behaves like the existing `mount_varlog` option.

Since Taupage already bundles a standard SSL certificates tree it helps application maintainers that want to use upstream images like busybox, which are very lightweight, but still need a valid certificate tree to operate correctly.

Most people just take the easy route which is to start from the zalando-ubuntu image but this adds hundreds of unnecessary MBs when the same can be achieved with only a couple MBs. This also helps Pierone

We've tested this approach with our Golang binary, using `FROM busybox:ubuntu-14.04`, which resulted in a 16MB container

I've discussed this with @sarnowski already and I'd like you guys to consider this suggestion.