### PR TITLE
chmod 600 to mon-put-instance-data-cloudwatch in cron.d

### DIFF
--- a/runtime/opt/taupage/init.d/04-enhanced-cloudwatch-metrics.sh
+++ b/runtime/opt/taupage/init.d/04-enhanced-cloudwatch-metrics.sh
@@ -8,5 +8,6 @@ if [ "$enhanced_cloudwatch_metrics" = True ] ; then
   if [ ! -f /etc/cron.d/mon-put-instance-data-cloudwatch ]; then
     echo "enhanced_cloudwatch_metrics detected...enabling additional cloudwatch metrics"
     mv /etc/cron.d/mon-put-instance-data-cloudwatch.deactivated /etc/cron.d/mon-put-instance-data-cloudwatch
+    chmod 600 /etc/cron.d/mon-put-instance-data-cloudwatch
   fi
 fi


### PR DESCRIPTION
Currently permissions for the cron.d file are following:

-rw-rw-r-- 1 root root 198 Dec 29 12:46 /etc/cron.d/mon-put-instance-data-cloudwatch

That causes cron execution to fail - actually it is not executed at all.

Dec 29 09:03:02 ip-172-31-170-215 cron[1149]: (*system*mon-put-instance-data-cloudwatch) INSECURE MODE (group/other writable) (/etc/cron.d/mon-put-instance-data-cloudwatch)

Fixed by adding chmod 600
