### PR TITLE
Set defaults for logrotate size for application.log

### DIFF
--- a/runtime/etc/logrotate.d/application
+++ b/runtime/etc/logrotate.d/application
@@ -2,7 +2,7 @@
 {
         rotate 4
         weekly
-        #size 10M
+        size 256M
         missingok
         notifempty
         copytruncate

--- a/runtime/opt/taupage/init.d/86-adjust-application-logrotate
+++ b/runtime/opt/taupage/init.d/86-adjust-application-logrotate
@@ -10,7 +10,7 @@ application_logrotate="/etc/logrotate.d/application"
 #set custom filesize 
 if [ -n "$config_application_logrotate_size" ]; then
 	echo "INFO: Set filesize to $config_application_logrotate_size for application.log Logrotate"
-        sed -i "s/\#size\b.*$/size $config_application_logrotate_size/g" $application_logrotate 
+        sed -i "s/\bsize\b.*$/size $config_application_logrotate_size/g" $application_logrotate 
 fi
 
 


### PR DESCRIPTION
Addresses issue #172 

in commit ce88fc7 the possibility to rotate on size was introduced.

However, the default is still that it only rotates on time. As the space for Taupage is limited, it might be best to limit the size of any single log to a decent amount.

With a rotate of 4, diskspace for Taupage being limited to a few GB, I would propose to change the
default from none to 256M