### PR TITLE
Node exporter - enable tcpstat collector, add test

### DIFF
--- a/runtime/etc/init/node_exporter.conf
+++ b/runtime/etc/init/node_exporter.conf
@@ -3,5 +3,5 @@
 start on startup
 
 script
-   /opt/taupage/bin/prometheus/node_exporter
+   /opt/taupage/bin/prometheus/node_exporter -collectors.enabled=diskstats,filesystem,loadavg,meminfo,stat,textfile,time,netdev,netstat,tcpstat
 end script

--- a/tests/spec/localhost/prometheus_spec.rb
+++ b/tests/spec/localhost/prometheus_spec.rb
@@ -3,3 +3,7 @@ require 'spec_helper'
 describe file('/opt/taupage/bin/prometheus/node_exporter') do
   it { should be_file }
 end
+
+describe service('node_exporter') do
+  it { should be_running }
+end


### PR DESCRIPTION
Adds tcpstat to the default prometheus plugin list, in order to see summary number of TCP connections.
Adds service running requirement to rspec test (it wasn't verified if works fine - test procedure is not described in `README.md`, i wasn't able to run serverspec on my own).