### PR TITLE
Use first port as default health check port

### DIFF
--- a/runtime/usr/local/lib/python3.4/dist-packages/taupage/__init__.py
+++ b/runtime/usr/local/lib/python3.4/dist-packages/taupage/__init__.py
@@ -75,10 +75,12 @@ def get_default_port(config: dict):
     8080
     >>> get_default_port({'ports': {80: 80, '8080/udp': 8080}})
     80
+    >>> get_default_port({'ports': {8080: 8080, 7979: 7979}})
+    8080
     '''
     tcp_ports = filter(is_tcp_port, get_or(config, 'ports', {}).keys())
     tcp_ports = map(integer_port, tcp_ports)
-    default_port = get_first(sorted(tcp_ports))
+    default_port = get_first(tcp_ports)
     return default_port
 
 


### PR DESCRIPTION
The [documentation][doc] says that the first port of `ports` is picked as default health check port. Remove the sorting to ensure that the implementation matches the documentation.

[doc]: https://stups.readthedocs.org/en/latest/components/taupage.html?highlight=first#health-check-path