### PR TITLE
Allow certain sysctl parameters to be overridden

### DIFF
--- a/runtime/opt/taupage/init.d/06-update-sysctl.py
+++ b/runtime/opt/taupage/init.d/06-update-sysctl.py
@@ -6,9 +6,9 @@ import subprocess
 
 from taupage import configure_logging, get_config
 
-SYSCTL_WHITELIST = ['vm.dirty_background_ratio', 'vm.dirty_ratio', 'vm.overcommit_memory', 'vm_swappiness',
-                    'vm.overcommit_ratio']
-SENZA_SYSCTL_CONF = '/etc/sysctl.d/99-senza.conf'
+SYSCTL_WHITELIST = ['vm.dirty_background_ratio', 'vm.dirty_ratio', 'vm.overcommit_memory', 'vm_overcommit_ratio',
+                    'vm.swapiness']
+CUSTOM_SYSCTL_CONF = '/etc/sysctl.d/99-custom.conf'
 
 
 def write_file(path, content):
@@ -33,7 +33,7 @@ def main():
 
     try:
         sysctl_entries = ['{} = {}'.format(key, value) for key, value in sysctl.items()]
-        write_file(SENZA_SYSCTL_CONF, '\n'.join(sysctl_entries)+'\n')
+        write_file(CUSTOM_SYSCTL_CONF, '\n'.join(sysctl_entries)+'\n')
         logging.info('Successfully written sysctl parameters')
     except Exception as e:
         logging.error('Failed to write sysctl parameters')
@@ -41,9 +41,9 @@ def main():
         sys.exit(1)
 
     try:
-        exitcode = subprocess.call(['/sbin/sysctl', '-p', SENZA_SYSCTL_CONF])
+        exitcode = subprocess.call(['/sbin/sysctl', '-p', CUSTOM_SYSCTL_CONF])
         if exitcode != 0:
-            logging.error('Reloading sysctl failed with exitcode {}'.format(+exitcode))
+            logging.error('Reloading sysctl failed with exitcode {}'.format(exitcode))
             sys.exit(1)
         logging.info('Successfully reloaded sysctl parameters')
     except Exception as e:

--- a/runtime/opt/taupage/init.d/06-update-sysctl.py
+++ b/runtime/opt/taupage/init.d/06-update-sysctl.py
@@ -29,7 +29,6 @@ def main():
     disallowed_keys = set(sysctl.keys()) - set(SYSCTL_WHITELIST)
     if disallowed_keys:
         logging.error('You are not allowed to configure the sysctl parameters {}'.format(list(disallowed_keys)))
-        sys.exit(1)
 
     try:
         sysctl_entries = ['{} = {}'.format(key, value) for key, value in sysctl.items()]

--- a/runtime/opt/taupage/init.d/06-update-sysctl.py
+++ b/runtime/opt/taupage/init.d/06-update-sysctl.py
@@ -6,8 +6,8 @@ import subprocess
 
 from taupage import configure_logging, get_config
 
-SYSCTL_WHITELIST = ['vm.dirty_background_ratio', 'vm.dirty_ratio', 'vm.overcommit_memory', 'vm_overcommit_ratio',
-                    'vm.swappiness']
+SYSCTL_WHITELIST = ['fs.file-max', 'vm.dirty_background_ratio', 'vm.dirty_ratio', 'vm.overcommit_memory',
+                    'vm_overcommit_ratio', 'vm.swappiness']
 CUSTOM_SYSCTL_CONF = '/etc/sysctl.d/99-custom.conf'
 
 

--- a/runtime/opt/taupage/init.d/06-update-sysctl.py
+++ b/runtime/opt/taupage/init.d/06-update-sysctl.py
@@ -7,7 +7,7 @@ import subprocess
 from taupage import configure_logging, get_config
 
 SYSCTL_WHITELIST = ['vm.dirty_background_ratio', 'vm.dirty_ratio', 'vm.overcommit_memory', 'vm_overcommit_ratio',
-                    'vm.swapiness']
+                    'vm.swappiness']
 CUSTOM_SYSCTL_CONF = '/etc/sysctl.d/99-custom.conf'
 
 

--- a/runtime/opt/taupage/init.d/06-update-sysctl.py
+++ b/runtime/opt/taupage/init.d/06-update-sysctl.py
@@ -6,8 +6,8 @@ import subprocess
 
 from taupage import configure_logging, get_config
 
-SYSCTL_WHITELIST = ['vm.dirty_background_ratio', 'vm.dirty_ratio', 'vm.overcommit_memory', 'vm_swappiness'
-                    , 'vm.overcommit_ratio']
+SYSCTL_WHITELIST = ['vm.dirty_background_ratio', 'vm.dirty_ratio', 'vm.overcommit_memory', 'vm_swappiness',
+                    'vm.overcommit_ratio']
 SENZA_SYSCTL_CONF = '/etc/sysctl.d/99-senza.conf'
 
 

--- a/runtime/opt/taupage/init.d/06-update-sysctl.py
+++ b/runtime/opt/taupage/init.d/06-update-sysctl.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+import logging
+import sys
+import subprocess
+
+from taupage import configure_logging, get_config
+
+SYSCTL_WHITELIST = ['vm.dirty_background_ratio', 'vm.dirty_ratio', 'vm.overcommit_memory', 'vm_swappiness'
+                    , 'vm.overcommit_ratio']
+SENZA_SYSCTL_CONF = '/etc/sysctl.d/99-senza.conf'
+
+
+def write_file(path, content):
+    with open(path, 'w') as file:
+        file.write(content)
+
+
+def main():
+    """If sysctl configuration is specified, writes sysctl configuration and reloads sysctl"""
+    configure_logging()
+    config = get_config()
+
+    sysctl = config.get('sysctl')
+
+    if sysctl is None:
+        sys.exit(0)
+
+    disallowed_keys = set(sysctl.keys()) - set(SYSCTL_WHITELIST)
+    if disallowed_keys:
+        logging.error('You are not allowed to configure the sysctl parameters {}'.format(list(disallowed_keys)))
+        sys.exit(1)
+
+    try:
+        sysctl_entries = ['{} = {}'.format(key, value) for key, value in sysctl.items()]
+        write_file(SENZA_SYSCTL_CONF, '\n'.join(sysctl_entries)+'\n')
+        logging.info('Successfully written sysctl parameters')
+    except Exception as e:
+        logging.error('Failed to write sysctl parameters')
+        logging.exception(e)
+        sys.exit(1)
+
+    try:
+        exitcode = subprocess.call(['/sbin/sysctl', '-p', SENZA_SYSCTL_CONF])
+        if exitcode != 0:
+            logging.error('Reloading sysctl failed with exitcode {}'.format(+exitcode))
+            sys.exit(1)
+        logging.info('Successfully reloaded sysctl parameters')
+    except Exception as e:
+        logging.error('Failed to reload sysctl')
+        logging.exception(e)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Tuning applications on top of Taupage sometimes requires tuning certain (kernel)
parameters. This allows Taupage configurations to have a sysctl section which
will be used instead of the defaults.
As some kernel parameters may not be allowed to be tuned, only parameters
on a whitelist are allowed to be specified.

This addresses issues:
* https://github.com/zalando-stups/taupage/issues/175
* https://github.com/zalando/spilo/issues/42