### PR TITLE
fix curl call to return with non-zero in case of error

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -135,7 +135,7 @@ max_tries=30  # ~3 minutes
 while [ true ]; do
     echo "Waiting for HTTP server..."
 
-    result=$(curl http://$ip/ 2>/dev/null)
+    result=$(curl --fail http://$ip/ 2>/dev/null)
     if [ $? -eq 0 ]; then
 
         TEST_OK=true


### PR DESCRIPTION
The test you built here seems incorrect, since curl will not exit with a non-zero exit code unless you request this explicitly.

    -f, --fail

       (HTTP) Fail silently (no output at all) on server errors. This is
       mostly done to better  enable  scripts  etc  to  better  deal
       with  failed attempts. In normal cases when an HTTP server fails
       to deliver a document, it returns an HTML document stating so
       (which often also describes why and more). This flag will prevent
       curl from outputting that and return error 22.

       This method is not fail-safe and there are occasions where
       non-successful response codes will slip through, especially when
       authentication is involved (response codes 401 and 407).

```
% curl --fail http://google.de/invalid
curl: (22) The requested URL returned error: 404 Not Found
% echo $?                                                                                :(
22
% curl http://google.de/invalid
<!DOCTYPE html>
<html lang=en>
  <meta charset=utf-8>
  <meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">
  <title>Error 404 (Not Found)!!1</title>
  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>
  <p><b>404.</b> <ins>That’s an error.</ins>
  <p>The requested URL <code>/invalid</code> was not found on this server.  <ins>That’s all we know.</ins>
```