### PR TITLE
Start docker container if it already exists. Fix #199

### DIFF
--- a/runtime/opt/taupage/runtime/Docker.py
+++ b/runtime/opt/taupage/runtime/Docker.py
@@ -304,7 +304,16 @@ def main(args):
         logging.error("Failed to list existing docker containers: %s", str(e))
         # not a fatal error, continue
 
-    if not already_exists:
+    if already_exists:
+        try:
+            cmd = ['docker', 'start', 'taupageapp']
+            logging.info('Starting existing Docker container: {}'.format(cmd))
+            if not args.dry_run:
+                subprocess.check_output(cmd)
+        except Exception as e:
+            logging.error('Docker start of existing container failed: %s', str(e))
+            sys.exit(1)
+    else:
         registry = extract_registry(source)
 
         if registry:


### PR DESCRIPTION
This is a workaround for an issue with startup sequence when we
have external volumes to mount.  In case of EC2 instance restart
the Docker daemon will start prior to taupage-init and will
immediately try to start the container it was running prior to
the restart.  This will fail because the volumes are not there yet,
they are mounted as part of taupage-init script, in 10-prepare-disks.py.

Starting the container explicitly "fixes" the problem because at that
point all required initialization steps are completed.