### PR TITLE
install xenial kernel 4.4.0-22-generic

### DIFF
--- a/build/setup.d/21-install-xenial-kernel.sh
+++ b/build/setup.d/21-install-xenial-kernel.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+DEBIAN_FRONTEND=noninteractive apt-get install -y -q --install-recommends -o Dpkg::Options::="--force-confold" linux-generic-lts-xenial >> install.log


### PR DESCRIPTION
as using the stock 14.04 kernel (3.13.X) is preventing sshd to work inside the docker image
after upgrading sshd.

example error output:

nor calling  with --capabilities-add AUDIT_WRITE nor --privileged=true resolved this.
A kernel upgrade on taupage and a reboot did help.