### PR TITLE
Add vm.max_map_count to sysctl whitelist

### DIFF
--- a/runtime/opt/taupage/init.d/06-update-sysctl.py
+++ b/runtime/opt/taupage/init.d/06-update-sysctl.py
@@ -18,6 +18,7 @@ def main():
     SYSCTL_WHITELIST = ['fs.file-max',
                         'vm.dirty_background_ratio',
                         'vm.dirty_ratio',
+                        'vm.max_map_count',
                         'vm.overcommit_memory',
                         'vm.overcommit_ratio',
                         'vm.swappiness',


### PR DESCRIPTION
We need this to configure PlanB Cassandra.  This parameter cannot be
changed from inside the Docker container.

https://issues.apache.org/jira/browse/CASSANDRA-3563
https://issues.apache.org/jira/secure/attachment/12505934/0001-increase-debian-limit.txt