### PR TITLE
Added vm.max_map_count to sysctl whitelist. Required by elasticsearch…

### DIFF
--- a/runtime/opt/taupage/init.d/06-update-sysctl.py
+++ b/runtime/opt/taupage/init.d/06-update-sysctl.py
@@ -18,6 +18,7 @@ def main():
     SYSCTL_WHITELIST = ['fs.file-max',
                         'vm.dirty_background_ratio',
                         'vm.dirty_ratio',
+                        'vm.max_map_count',
                         'vm.overcommit_memory',
                         'vm.overcommit_ratio',
                         'vm.swappiness',


### PR DESCRIPTION
… component of sonarqube (https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-configuration.html)