### PR TITLE
enabling appdynamics machine agent http listener

### DIFF
--- a/runtime/etc/init/appdynamics.conf
+++ b/runtime/etc/init/appdynamics.conf
@@ -6,5 +6,5 @@ respawn
 
 script
 	/opt/proprietary/appdynamics-machine/bin/machine-agent \
-	  -D appdynamics.agent.uniqueHostId=$(cat /opt/proprietary/appdynamics-machine/uniqueHostId) -D java.net.preferIPv4Stack=true
+	  -D appdynamics.agent.uniqueHostId=$(cat /opt/proprietary/appdynamics-machine/uniqueHostId) -D java.net.preferIPv4Stack=true -Dmetric.http.listener=true
 end script

--- a/runtime/etc/init/appdynamics.conf
+++ b/runtime/etc/init/appdynamics.conf
@@ -6,5 +6,5 @@ respawn
 
 script
 	/opt/proprietary/appdynamics-machine/bin/machine-agent \
-	  -D appdynamics.agent.uniqueHostId=$(cat /opt/proprietary/appdynamics-machine/uniqueHostId) -D java.net.preferIPv4Stack=true -Dmetric.http.listener=true
+	  -D appdynamics.agent.uniqueHostId=$(cat /opt/proprietary/appdynamics-machine/uniqueHostId) -D java.net.preferIPv4Stack=true -Dmetric.http.listener=true -Dmetric.http.listener.port=8293 -Dmetric.http.listener.host=0.0.0.0
 end script


### PR DESCRIPTION
I would like to send custom metrics to the machine-agent http listener as described in:

https://docs.appdynamics.com/display/PRO41/Standalone+Machine+Agent+HTTP+Listener

Is there a possibility of adding this option by default to `appdynamics.conf` ?