### PR TITLE
Resize mounts by default

### DIFF
--- a/runtime/opt/taupage/init.d/10-prepare-disks.py
+++ b/runtime/opt/taupage/init.d/10-prepare-disks.py
@@ -125,6 +125,9 @@ def iterate_mounts(config):
         def mount():
             mount_partition(partition, mountpoint, options, filesystem, os.path.isdir(mountpoint), already_mounted)
 
+        def resize():
+            subprocess.check_call(['resize2fs', partition])
+
         if partition and not already_mounted:
             if initialize:
                 format()
@@ -137,6 +140,11 @@ def iterate_mounts(config):
                     initialize = True
                     format()
                     mount()
+
+            try:
+                resize()
+            except Exception as e:
+                logging.warning("Could not resize partition %s: %s", partition, str(e))
 
 
 def handle_ebs_volumes(args, ebs_volumes):


### PR DESCRIPTION
Volumes that should not be erased_on_boot may have been created
from different snapshots. One of the reasons to do this is to be able
to scale data stores (PostgreSQL, Cassandra) once they fill up.
What happens in this case is that the volume is resized, however the
filesystem still has the previous size.
Resizing the filesystem to the volume seems like a win, we can do
it unconditionally as resize2fs will figure out by itself whether
a resize is needed.

Addresses issue #252