### PR TITLE
remove whitelist for setting sysctl values

### DIFF
--- a/runtime/opt/taupage/init.d/06-update-sysctl.py
+++ b/runtime/opt/taupage/init.d/06-update-sysctl.py
@@ -11,18 +11,7 @@ def main():
     """Configure custom sysctl parameters
 
     If a sysctl section is present, add the valid parameters to sysctl and reloads.
-
-    As some kernel parameters may not be allowed to be tuned, only parameters
-    on a whitelist are allowed to be specified.
     """
-    SYSCTL_WHITELIST = ['fs.file-max',
-                        'vm.dirty_background_ratio',
-                        'vm.dirty_ratio',
-                        'vm.max_map_count',
-                        'vm.overcommit_memory',
-                        'vm.overcommit_ratio',
-                        'vm.swappiness',
-                        'net.core.somaxconn']
     CUSTOM_SYSCTL_CONF = '/etc/sysctl.d/99-custom.conf'
 
     configure_logging()
@@ -33,12 +22,8 @@ def main():
     if sysctl is None:
         sys.exit(0)
 
-    disallowed_keys = set(sysctl.keys()) - set(SYSCTL_WHITELIST)
-    if disallowed_keys:
-        logging.error('You are not allowed to configure the sysctl parameters {}'.format(list(disallowed_keys)))
-
     try:
-        sysctl_entries = ['{} = {}'.format(key, value) for key, value in sysctl.items() if key in SYSCTL_WHITELIST]
+        sysctl_entries = ['{} = {}'.format(key, value) for key, value in sysctl.items()]
         with open(CUSTOM_SYSCTL_CONF, 'w') as file:
             file.write('\n'.join(sysctl_entries)+'\n')
         logging.info('Successfully written sysctl parameters')


### PR DESCRIPTION
There is no reason to have a whitelist, because settings are tracked in git senza repos.
To tune contrack table timeouts we need to tune socket parameters here.