### PR TITLE
push-audit-logs.py should spread the requests to audit API #296

### DIFF
--- a/runtime/opt/taupage/bin/push-audit-logs.py
+++ b/runtime/opt/taupage/bin/push-audit-logs.py
@@ -7,6 +7,7 @@ import gzip
 import json
 import logging
 import os
+import random
 import requests
 import sys
 import time
@@ -76,7 +77,8 @@ def main():
             for fn in glob.glob('/var/log/audit.log'):
                 push_audit_log(config, instance_logs_url, account_id, region, instance_id, boot_time, fn, compress=True)
             return
-        time.sleep(60)
+        rtime = random.randrange(60, 3000)
+        time.sleep(rtime)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Used a random integer between 60 and 3500 seconds to send data, after the first of the script run, such that on shutdown it will processed without sleep.