### PR TITLE
Wait for devices to become available more reliably

### DIFF
--- a/runtime/opt/taupage/init.d/10-prepare-disks.py
+++ b/runtime/opt/taupage/init.d/10-prepare-disks.py
@@ -57,13 +57,18 @@ def attach_volume(ec2, volume_id, attach_as):
         sys.exit(3)
 
 
-def wait_for_device(device, max_tries=3, wait_time=5):
+def wait_for_device(device, max_tries=12, wait_time=5):
     """Gives device some time to be available in case it was recently attached"""
     tries = 0
-    while tries < max_tries and not os.path.exists(device):
+    while tries < max_tries:
+        if os.path.exists(device):
+            return
         logging.info("Waiting for %s to stabilize..", device)
         tries += 1
         sleep(wait_time)
+    logging.error("Failed to wait for %s device to become available after %s seconds",
+                  device, max_tries * wait_time)
+    sys.exit(2)
 
 
 def format_partition(partition, filesystem="ext4", initialize=False, is_already_mounted=False, is_root=False):


### PR DESCRIPTION
- Increase default wait timeout to 60 seconds.
- Exit with error code if the device doesn't appear after timeout.