### PR TITLE
#318 blow up on human error (wrong type in YAML)

### DIFF
--- a/runtime/opt/taupage/init.d/10-prepare-disks.py
+++ b/runtime/opt/taupage/init.d/10-prepare-disks.py
@@ -142,6 +142,9 @@ def iterate_mounts(config):
         partition = data.get("partition")
         filesystem = data.get("filesystem", "ext4")
         initialize = data.get("erase_on_boot", False)
+        if not isinstance(initialize, bool):
+            logging.error('"erase_on_boot" must be boolean')
+            sys.exit(2)
         options = data.get('options')
         already_mounted = os.path.ismount(mountpoint)
 


### PR DESCRIPTION
Fixes #318.

Blow up if the user mistakenly enters a string in the user data YAML for `erase_on_boot` parameter.

This will prevent "frequent" errors like putting the string "false" into the YAML (non-empty string evaluates to `True`).