### PR TITLE
add yaml-dev for building python yaml dependency with pip

### DIFF
--- a/build/setup.d/20-install-packages.sh
+++ b/build/setup.d/20-install-packages.sh
@@ -16,6 +16,7 @@ libruby1.9.1
 libssl-dev
 libswitch-perl
 libwww-perl
+libyaml-dev
 libyaml-0-2
 linux-image-extra-virtual-lts-utopic
 logentries


### PR DESCRIPTION
While this does not break the build, it's a bug that should be fixed