### PR TITLE
Do not format for e2fsck with exitcode 8

### DIFF
--- a/runtime/opt/taupage/init.d/10-prepare-disks.py
+++ b/runtime/opt/taupage/init.d/10-prepare-disks.py
@@ -129,8 +129,7 @@ def check_partition(partition, filesystem):
             elif (e.returncode & 4) != 0:
                 logging.exception("File system errors left uncorrected on %s.", partition)
             elif e.returncode == 8:
-                # must be an unformatted or unrecoverable partition
-                raise
+                logging.exception("Operational error %s.", partition)
             elif e.returncode >= 16:
                 logging.exception("Unexpected error when checking %s.", partition)
             sys.exit(2)


### PR DESCRIPTION
Do not format for e2fsck with exitcode 8, because our Go-CD pipeline server was deleted, because of that