### PR TITLE
Fix use of EC2 client in prepare disks script

### DIFF
--- a/runtime/opt/taupage/init.d/10-prepare-disks.py
+++ b/runtime/opt/taupage/init.d/10-prepare-disks.py
@@ -14,6 +14,9 @@ from time import sleep
 from taupage import configure_logging, get_config
 
 
+current_region = None
+
+
 def instance_id():
     """Helper to return theid for the current instance"""
     return boto.utils.get_instance_metadata()['instance-id']
@@ -27,6 +30,10 @@ def region():
 def zone():
     """Helper to return the AZ for the current instance"""
     return boto.utils.get_instance_metadata()['placement']['availability-zone']
+
+
+def ec2_client():
+    return boto.ec2.connect_to_region(current_region)
 
 
 def find_volume(ec2, name):
@@ -182,7 +189,7 @@ def extend_partition(partition, mountpoint, filesystem):
 ERASE_ON_BOOT_TAG_NAME = 'Taupage:erase-on-boot'
 
 
-def should_format_volume(ec2, partition, erase_on_boot):
+def should_format_volume(partition, erase_on_boot):
     """
 We need to take a safe decision whether to format a volume or not
 based on two inputs: value of user data flag and EBS volume tag.  The
@@ -202,21 +209,27 @@ Data \ Tag | T | F
          N | ! | -
     """
     erase_tag_set = False
+    #
+    # We should only try to query the EBS tags if user data doesn't
+    # tell us anything: otherwise this will crash the instances which
+    # don't have any role attached.
+    #
+    if erase_on_boot is None:
+        ec2 = ec2_client()
+        volumes = list(ec2.get_all_volumes(filters={
+            'attachment.instance-id': instance_id(),
+            'attachment.device': partition}))
+        if volumes:
+            volume_id = volumes[0].id
+            logging.info("%s: volume_id=%s", partition, volume_id)
 
-    volumes = list(ec2.get_all_volumes(filters={
-        'attachment.instance-id': instance_id(),
-        'attachment.device': partition}))
-    if volumes:
-        volume_id = volumes[0].id
-        logging.info("%s: volume_id=%s", partition, volume_id)
-
-        tags = ec2.get_all_tags(filters={
-            'resource-id': volume_id,
-            'key': ERASE_ON_BOOT_TAG_NAME,
-            'value': 'True'})
-        if list(tags):
-            ec2.delete_tags(volume_id, [ERASE_ON_BOOT_TAG_NAME])
-            erase_tag_set = True
+            tags = ec2.get_all_tags(filters={
+                'resource-id': volume_id,
+                'key': ERASE_ON_BOOT_TAG_NAME,
+                'value': 'True'})
+            if list(tags):
+                ec2.delete_tags(volume_id, [ERASE_ON_BOOT_TAG_NAME])
+                erase_tag_set = True
 
     logging.info("%s: erase_on_boot=%s, erase_tag_set=%s",
                  partition, erase_on_boot, erase_tag_set)
@@ -224,7 +237,7 @@ Data \ Tag | T | F
     return erase_on_boot or (erase_on_boot is None and erase_tag_set)
 
 
-def iterate_mounts(ec2, config, max_tries=12, wait_time=5):
+def iterate_mounts(config, max_tries=12, wait_time=5):
     """Iterates over mount points file to provide disk device paths"""
     for mountpoint, data in config.get("mounts", {}).items():
         # mount path below /mounts on the host system
@@ -237,7 +250,7 @@ def iterate_mounts(ec2, config, max_tries=12, wait_time=5):
         if not(isinstance(erase_on_boot, bool) or erase_on_boot is None):
             logging.error('"erase_on_boot" must be boolean')
             sys.exit(2)
-        initialize = should_format_volume(ec2, partition, erase_on_boot)
+        initialize = should_format_volume(partition, erase_on_boot)
         options = data.get('options')
         already_mounted = os.path.ismount(mountpoint)
 
@@ -274,7 +287,8 @@ def iterate_mounts(ec2, config, max_tries=12, wait_time=5):
                     sys.exit(2)
 
 
-def handle_ebs_volumes(ec2, ebs_volumes):
+def handle_ebs_volumes(ebs_volumes):
+    ec2 = ec2_client()
     for device, name in ebs_volumes.items():
         if os.path.exists(device):
             logging.info("Device already exists %s", device)
@@ -340,13 +354,13 @@ def handle_raid_volumes(raid_volumes):
             create_raid_device(raid_device, raid_config)
 
 
-def handle_volumes(ec2, config):
+def handle_volumes(config):
     """Try to attach volumes"""
     volumes = config.get("volumes", {})
 
     # attach ESB volumes first
     if "ebs" in volumes:
-        handle_ebs_volumes(ec2, volumes.get("ebs"))
+        handle_ebs_volumes(volumes.get("ebs"))
 
     # then take care of any RAID definitions
     if "raid" in volumes:
@@ -372,17 +386,17 @@ def main():
     else:
         configure_logging(logging.INFO)
 
+    global current_region
+    current_region = args.region if args.region else region()
+
     # Load configuration from YAML file
     config = get_config(args.filename)
 
-    current_region = args.region if args.region else region()
-    ec2 = boto.ec2.connect_to_region(current_region)
-
     if config.get("volumes"):
-        handle_volumes(ec2, config)
+        handle_volumes(config)
 
     # Iterate over mount points
-    iterate_mounts(ec2, config)
+    iterate_mounts(config)
 
 
 if __name__ == '__main__':

--- a/runtime/opt/taupage/init.d/10-prepare-disks.py
+++ b/runtime/opt/taupage/init.d/10-prepare-disks.py
@@ -19,7 +19,7 @@ def instance_id():
     return boto.utils.get_instance_metadata()['instance-id']
 
 
-def region():
+def detect_region():
     """Helper to return the region for the current instance"""
     return boto.utils.get_instance_metadata()['placement']['availability-zone'][:-1]
 
@@ -234,7 +234,7 @@ Data \ Tag | T | F
     return erase_on_boot or (erase_on_boot is None and erase_tag_set)
 
 
-def iterate_mounts(config, max_tries=12, wait_time=5):
+def iterate_mounts(region, config, max_tries=12, wait_time=5):
     """Iterates over mount points file to provide disk device paths"""
     for mountpoint, data in config.get("mounts", {}).items():
         # mount path below /mounts on the host system
@@ -247,7 +247,7 @@ def iterate_mounts(config, max_tries=12, wait_time=5):
         if not(isinstance(erase_on_boot, bool) or erase_on_boot is None):
             logging.error('"erase_on_boot" must be boolean')
             sys.exit(2)
-        initialize = should_format_volume(partition, erase_on_boot)
+        initialize = should_format_volume(region, partition, erase_on_boot)
         options = data.get('options')
         already_mounted = os.path.ismount(mountpoint)
 
@@ -383,7 +383,7 @@ def main():
     else:
         configure_logging(logging.INFO)
 
-    current_region = args.region if args.region else region()
+    current_region = args.region if args.region else detect_region()
 
     # Load configuration from YAML file
     config = get_config(args.filename)


### PR DESCRIPTION
Only require a client when actually needed, avoid doing that on script
startup: instances running without any role assigned will just have an
exception there.