### PR TITLE
bugfix: forgot to rename drv->module when refactoring

### DIFF
--- a/build/setup.d/10-upgrade-base.sh
+++ b/build/setup.d/10-upgrade-base.sh
@@ -17,7 +17,7 @@ function configure_dkms() {
     local MODULE_LOCATION=$4
 
     cat > ${PACKAGE_NAME}-${PACKAGE_VERSION}/dkms.conf << EOF
-PACKAGE_NAME="${DRV_NAME}"
+PACKAGE_NAME="${MODULE_NAME}"
 PACKAGE_VERSION="${IXGBEVF_VERSION}"
 CLEAN="cd src/; make clean"
 MAKE="cd src/; make BUILD_KERNEL=\${kernelver}"


### PR DESCRIPTION
dkms.conf: Error! No 'PACKAGE_NAME' directive specified.