### PR TITLE
Kernel upgrade: utopic->xenial

### DIFF
--- a/build/setup.d/10-upgrade-base.sh
+++ b/build/setup.d/10-upgrade-base.sh
@@ -8,7 +8,7 @@ echo "Updating system..."
 apt-get update -y  # -q >>/tmp/build/upgrade.log
 
 # install kernel headers and dkms
-apt-get install -y linux-headers-generic-lts-utopic dkms
+apt-get install -y linux-headers-generic-lts-xenial dkms
 
 function configure_dkms() {
     local PACKAGE_NAME=$1
@@ -54,7 +54,7 @@ popd
 
 # install 3.16. LTS kernel and make sure it updates to the last version
 # also this step should build ixgbevf and ena kernel modules and put them into initramfs
-apt-get install -y linux-image-virtual-lts-utopic
+apt-get install -y linux-image-virtual-lts-xenial
 
 apt-mark hold openssh-server
 apt-get install -y --only-upgrade libc6 libssl1.0.0

--- a/build/setup.d/20-install-packages.sh
+++ b/build/setup.d/20-install-packages.sh
@@ -18,7 +18,7 @@ libswitch-perl
 libwww-perl
 libyaml-dev
 libyaml-0-2
-linux-image-extra-virtual-lts-utopic
+linux-image-extra-virtual-lts-xenial
 logentries
 logentries-daemon
 mdadm

--- a/build/setup.d/89-remove-packages.sh
+++ b/build/setup.d/89-remove-packages.sh
@@ -8,7 +8,7 @@ g++-4.8
 gcc
 gcc-4.8
 laptop-detect
-linux-headers-generic-lts-utopic
+linux-headers-generic-lts-xenial
 dkms
 "
 


### PR DESCRIPTION
AWS recommend to run Ubuntu 16.04 for NVMe support: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ssd-instance-store.html
We don't want to change base image, but it make sense at least upgrade kernel to xenial.