### PR TITLE
install awscli from PyPI (awslogs-agent-setup.py needs it)

### DIFF
--- a/build/setup.d/25-install-python-packages.sh
+++ b/build/setup.d/25-install-python-packages.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 pkgs="
+awscli
 boto
 boto3
 botocore


### PR DESCRIPTION
```
08:01:33.128 --2017-05-09 08:01:33--  https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py
08:01:33.131 Resolving s3.amazonaws.com (s3.amazonaws.com)... 52.216.226.211
08:01:33.219 Connecting to s3.amazonaws.com (s3.amazonaws.com)|52.216.226.211|:443... connected.
08:01:33.496 HTTP request sent, awaiting response... 200 OK
08:01:33.496 Length: 54087 (53K) [text/x-python-script]
08:01:33.496 Saving to: ‘awslogs-agent-setup.py’
08:01:33.585 
08:01:33.761      0K .......... .......... .......... .......... .......... 94%  232K 0s
08:01:33.762     50K ..                                                    100% 56.0K=0.3s
08:01:33.762 
08:01:33.762 2017-05-09 08:01:33 (199 KB/s) - ‘awslogs-agent-setup.py’ saved [54087/54087]
08:01:33.762 
08:01:33.762 ++ chmod +x ./awslogs-agent-setup.py
08:01:33.762 ++ ./awslogs-agent-setup.py -n -r foo -c cloudwatch_logs_empty.conf
08:01:37.939 
08:01:39.851 Step 1 of 5: Installing pip ...DONE
08:01:39.851 
08:01:50.053 Traceback (most recent call last):
08:01:50.053   File "./awslogs-agent-setup.py", line 1272, in <module>
08:01:50.053     main()
08:01:50.053   File "./awslogs-agent-setup.py", line 1268, in main
08:01:50.053     setup.setup_artifacts()
08:01:50.053   File "./awslogs-agent-setup.py", line 813, in setup_artifacts
08:01:50.053     self.install_awslogs_cli()
08:01:50.053   File "./awslogs-agent-setup.py", line 552, in install_awslogs_cli
08:01:50.053     subprocess.call([AWSCLI_CMD, 'configure', 'set', 'plugins.cwlogs', 'cwlogs'], env=DEFAULT_ENV)
08:01:50.053   File "/usr/lib/python2.7/subprocess.py", line 522, in call
08:01:50.054     return Popen(*popenargs, **kwargs).wait()
08:01:50.054   File "/usr/lib/python2.7/subprocess.py", line 710, in __init__
08:01:50.054     errread, errwrite)
08:01:50.054   File "/usr/lib/python2.7/subprocess.py", line 1327, in _execute_child
08:01:50.054     raise child_exception
08:01:50.054 OSError: [Errno 2] No such file or directory
08:01:50.060 Step 2 of 5: Downloading the latest CloudWatch Logs agent bits ... Build failed
08:01:50.060 Terminating server...
08:01:51.317 [go] Current job status: failed.