### PR TITLE
revert awslogs installer to 1.3.9

### DIFF
--- a/build/setup.d/71-install-cloudwatch-logs-agent.sh
+++ b/build/setup.d/71-install-cloudwatch-logs-agent.sh
@@ -7,7 +7,7 @@ cd /tmp/cw-logs-setup
 touch cloudwatch_logs_empty.conf
 
 # download and install latest version of the cloudwatch logs agent
-wget https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py
+wget https://s3.amazonaws.com/aws-cloudwatch/downloads/1.3.9/awslogs-agent-setup.py
 chmod +x ./awslogs-agent-setup.py
 
 # the region parameter is not relevant here but required


### PR DESCRIPTION
The latest version is broken for us, so revert to 1.3.9..

```
08:55:41.719 --2017-05-09 08:55:41--  https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py
08:55:41.723 Resolving s3.amazonaws.com (s3.amazonaws.com)... 52.216.32.3
08:55:41.812 Connecting to s3.amazonaws.com (s3.amazonaws.com)|52.216.32.3|:443... connected.
08:55:42.099 HTTP request sent, awaiting response... 200 OK
08:55:42.099 Length: 54087 (53K) [text/x-python-script]
08:55:42.099 Saving to: ‘awslogs-agent-setup.py’
08:55:42.188 
08:55:42.276      0K .......... .......... .......... .......... .......... 94%  283K 0s
08:55:42.277     50K ..                                                    100% 50.5M=0.2s
08:55:42.277 
08:55:42.277 2017-05-09 08:55:42 (299 KB/s) - ‘awslogs-agent-setup.py’ saved [54087/54087]
08:55:42.277 
08:55:42.277 ++ chmod +x ./awslogs-agent-setup.py
08:55:42.278 ++ ./awslogs-agent-setup.py -n -r foo -c cloudwatch_logs_empty.conf
08:55:46.462 
08:55:48.519 Step 1 of 5: Installing pip ...DONE
08:55:48.519 
08:55:59.250 Traceback (most recent call last):
08:55:59.250   File "./awslogs-agent-setup.py", line 1272, in <module>
08:55:59.250     main()
08:55:59.250   File "./awslogs-agent-setup.py", line 1268, in main
08:55:59.250     setup.setup_artifacts()
08:55:59.251   File "./awslogs-agent-setup.py", line 813, in setup_artifacts
08:55:59.251     self.install_awslogs_cli()
08:55:59.251   File "./awslogs-agent-setup.py", line 552, in install_awslogs_cli
08:55:59.251     subprocess.call([AWSCLI_CMD, 'configure', 'set', 'plugins.cwlogs', 'cwlogs'], env=DEFAULT_ENV)
08:55:59.251   File "/usr/lib/python2.7/subprocess.py", line 522, in call
08:55:59.251     return Popen(*popenargs, **kwargs).wait()
08:55:59.251   File "/usr/lib/python2.7/subprocess.py", line 710, in __init__
08:55:59.251     errread, errwrite)
08:55:59.252   File "/usr/lib/python2.7/subprocess.py", line 1327, in _execute_child
08:55:59.252     raise child_exception
08:55:59.252 OSError: [Errno 2] No such file or directory
08:55:59.266 Step 2 of 5: Downloading the latest CloudWatch Logs agent bits ... Build failed
```