### PR TITLE
Fix logrotation for docker and etcd

### DIFF
--- a/build/files
+++ b/build/files
@@ -31,6 +31,8 @@
 /etc/logrotate.d/application root:root 0644
 /etc/logrotate.d/auditlog root:root 0644
 /etc/logrotate.d/custom root:root 0644
+/etc/logrotate.d/docker root:root 0644
+/etc/logrotate.d/etcd root:root 0644
 /etc/logrotate.d/rsyslog root:root 0644
 
 /etc/default/docker root:root 0755

--- a/runtime/etc/logrotate.d/docker
+++ b/runtime/etc/logrotate.d/docker
@@ -1,7 +1,7 @@
 /var/log/upstart/docker.log {
         daily
         missingok
-        size 50m
+        size 50M
         rotate 7
         compress
         notifempty


### PR DESCRIPTION
Logrotation introduced in #397 was not working because of wrong file permission of the logrotate file and an invalid size definition.

This fixes the logrotation also for etcd which also had the wrong file permissions (introduced in #355)