### PR TITLE
Use compliant images in tests

### DIFF
--- a/test-batchdata.yaml
+++ b/test-batchdata.yaml
@@ -4,7 +4,7 @@ application_id: my-http-test-batch-ami
 application_version: "1.0"
 
 runtime: Docker
-source: fatz/docker-simple-job:latest
+source: registry.opensource.zalan.do/teapot/docker-simple-job:86842dc
 
 environment:
   EXIT: 0

--- a/test-userdata.yaml
+++ b/test-userdata.yaml
@@ -4,7 +4,7 @@ application_id: my-http-test-app-ami
 application_version: "1.6"
 
 runtime: Docker
-source: registry.opensource.zalan.do/stups/tiny-docker-http-test:1.6
+source: registry.opensource.zalan.do/teapot/tiny-docker-http-test:0.1
 
 environment:
   STAGE: ami-test


### PR DESCRIPTION
Use images which are build and served in a compliant way. E.g. has correct scm-source.json and originates from our registry.