### PR TITLE
Fix tiny-docker-http-test image

### DIFF
--- a/images/tiny-docker-http-test/Dockerfile
+++ b/images/tiny-docker-http-test/Dockerfile
@@ -1,8 +1,10 @@
-FROM scratch
-MAINTAINER Henning Jacobs <henning@jacobs1.de>
+FROM ubuntu:14.04
+MAINTAINER Team Teapot @ Zalando SE <team-teapot@zalando.de>
 
 # add scm-source
 ADD scm-source.json /
+
+COPY resources /resources
 
 # add binary
 ADD build/linux/tiny-docker-http-test /

--- a/images/tiny-docker-http-test/main.go
+++ b/images/tiny-docker-http-test/main.go
@@ -1,85 +1,90 @@
 package main
 
 import (
-        "fmt"
-        "net/http"
-        "os/exec"
-        "io/ioutil"
-        "math/rand"
-        "encoding/json"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"os/exec"
 )
 
 type Response struct {
-        Version string `json:"dockerVersion,omitempty"`
-        Success string `json:"success"`
-        Output  string `json:"output"`
+	Version string `json:"dockerVersion,omitempty"`
+	Success string `json:"success"`
+	Output  string `json:"output"`
 }
 
 func check(e error) {
-        if e != nil {
-                panic(e)
-        }
+	if e != nil {
+		panic(e)
+	}
 }
 
 func buildRandomImage() (*map[string]string, error) {
-        fmt.Println("Creating random file..")
-        size := 32
-        rb := make([]byte, size)
-        _, err := rand.Read(rb)
-        check(err)
-        err = ioutil.WriteFile("./resources/random", rb, 0644)
-        check(err)
-        out, err := exec.Command("docker", "build", "--no-cache", "./resources").Output()
-        result := make(map[string]string)
-        result["output"] = string(out)
-        return &result, err
+	fmt.Println("Creating random file..")
+	size := 32
+	rb := make([]byte, size)
+	_, err := rand.Read(rb)
+	check(err)
+	err = ioutil.WriteFile("./resources/random", rb, 0644)
+	check(err)
+	out, err := exec.Command("docker", "build", "--no-cache", "./resources").Output()
+	result := make(map[string]string)
+	if err != nil {
+		result["output"] = err.Error()
+	} else {
+		result["output"] = string(out)
+	}
+	return &result, err
 }
 
 func checkDockerVersion() (*map[string]string, error) {
-        out, err := exec.Command("docker", "-v").Output()
-        result := make(map[string]string)
-        if err != nil {
-                result["output"] = string(out)
-                return &result, err
-        }
-        result["version"] = string(out)
-        return &result, nil
+	out, err := exec.Command("docker", "-v").Output()
+	result := make(map[string]string)
+	if err != nil {
+		result["output"] = string(out)
+		return &result, err
+	}
+	result["version"] = string(out)
+	return &result, nil
 }
 
 func handler(w http.ResponseWriter, r *http.Request) {
-        w.Header().Set("Content-Type", "application/json")
-        fmt.Printf("Handling %s request for %s from %s..\n", r.Method, r.URL, r.RemoteAddr)
-        dockerVersionResult, err := checkDockerVersion()
-        if err != nil {
-                response := &Response{Success:"false", Output:(*dockerVersionResult)["output"]}
-                json, err := json.Marshal(response)
-                check(err)
-                w.WriteHeader(http.StatusNotFound)
-                w.Write(json)
-                return
-        }
-        fmt.Println("Using docker client", (*dockerVersionResult)["version"])
-        imgCreationResult, err := buildRandomImage()
-        if err != nil {
-                response := &Response{Success:"false", Output:(*imgCreationResult)["output"]}
-                json, err := json.Marshal(response)
-                check(err)
-                w.WriteHeader(http.StatusNotFound)
-                w.Write(json)
-                return
-        }
-        response := &Response{
-                Success:"true",
-                Output:(*imgCreationResult)["output"],
-                Version:(*dockerVersionResult)["version"]}
-        json, err := json.Marshal(response)
-        check(err)
-        w.Write(json)
+	w.Header().Set("Content-Type", "application/json")
+	fmt.Printf("Handling %s request for %s from %s..\n", r.Method, r.URL, r.RemoteAddr)
+	dockerVersionResult, err := checkDockerVersion()
+	if err != nil {
+		fmt.Println("ERROR: Something went wrong when checking docker version:", err.Error())
+		response := &Response{Success: "false", Output: err.Error()}
+		json, err := json.Marshal(response)
+		check(err)
+		w.WriteHeader(http.StatusNotFound)
+		w.Write(json)
+		return
+	}
+	fmt.Println("Using docker client", (*dockerVersionResult)["version"])
+	imgCreationResult, err := buildRandomImage()
+	if err != nil {
+		fmt.Println("ERROR: Something went wrong when building docker image:", err.Error())
+		response := &Response{Success: "false", Output: err.Error()}
+		json, err := json.Marshal(response)
+		check(err)
+		w.WriteHeader(http.StatusNotFound)
+		w.Write(json)
+		return
+	}
+	response := &Response{
+		Success: "true",
+		Output:  (*imgCreationResult)["output"],
+		Version: (*dockerVersionResult)["version"]}
+	json, err := json.Marshal(response)
+	check(err)
+	w.Write(json)
 }
 
 func main() {
-        http.HandleFunc("/", handler)
-        fmt.Println("Listening on port 8080..")
-        http.ListenAndServe(":8080", nil)
+	http.HandleFunc("/", handler)
+	fmt.Println("Listening on port 8080..")
+	http.ListenAndServe(":8080", nil)
 }
-


### PR DESCRIPTION
Adds the changes from this PR https://github.com/hjacobs/tiny-docker-http-test/pull/2 which we have been using since https://github.com/zalando-stups/taupage/commit/d80ccb648f0659fbbfb13037c5befce217df64ea anyway.

It uses an ubuntu base image rather than scratch, because mounting `/usr/bin/docker` like we do when running this image, does not work unless you have stuff like libpthread, libdevmapper etc. in the container.