### PR TITLE
Nodiscard and 3 attempts to find volumes

### DIFF
--- a/runtime/opt/taupage/init.d/10-prepare-disks.py
+++ b/runtime/opt/taupage/init.d/10-prepare-disks.py
@@ -130,14 +130,15 @@ def format_partition(partition, filesystem="ext4", initialize=False, is_already_
     """Formats disks if initialize is True"""
     if initialize and not is_already_mounted and filesystem != 'tmpfs':
         call = ["mkfs." + filesystem]
-        if not is_root:
-            if filesystem.startswith("ext"):
+        if filesystem.startswith("ext"):
+            extended_options = ['nodiscard']
+            if not is_root:
                 logging.debug("%s being formatted with unprivileged user as owner")
                 entry = pwd.getpwnam('application')
-                call.append("-E")
-                call.append("nodiscard,root_owner={}:{}".format(entry.pw_uid, entry.pw_gid))
-            elif filesystem == 'xfs':
-                call.append('-K')  # nodiscard argument for mkfs.xfs
+                extended_options.append("root_owner={}:{}".format(entry.pw_uid, entry.pw_gid))
+            call.extend(["-E", ",".join(extended_options)])
+        elif filesystem == 'xfs':
+            call.append('-K')  # nodiscard argument for mkfs.xfs
         call.append(partition)
         wait_for_device(partition)
         call_command(call)


### PR DESCRIPTION
* Bugfix: extended-options formatting options were not applied when container was starting as a root user.
* Do 3 attempts with 60 seconds interval to find "available" volumes 