### PR TITLE
Add support to --shm-size in docker configuration

### DIFF
--- a/runtime/opt/taupage/runtime/Docker.py
+++ b/runtime/opt/taupage/runtime/Docker.py
@@ -278,6 +278,9 @@ def get_other_options(config: dict):
     if config.get('read_only'):
         yield '--read-only'
 
+    # set shm_size
+    if config.get('shm_size'):
+        yield '--shm-size={}'.format(config.get('shm_size'))
 
 def extract_registry(docker_image: str) -> str:
     """

--- a/runtime/opt/taupage/runtime/Docker.py
+++ b/runtime/opt/taupage/runtime/Docker.py
@@ -282,6 +282,7 @@ def get_other_options(config: dict):
     if config.get('shm_size'):
         yield '--shm-size={}'.format(config.get('shm_size'))
 
+
 def extract_registry(docker_image: str) -> str:
     """
     >>> extract_registry('nginx')


### PR DESCRIPTION
Enable usage of `--shm-size` within senza definition files.