### PR TITLE
Send ntp traffic via NAT-GW

### DIFF
--- a/runtime/opt/taupage/init.d/00-create-custom-routing.py
+++ b/runtime/opt/taupage/init.d/00-create-custom-routing.py
@@ -66,6 +66,8 @@ def main():
     subprocess_call(iptables + ['-A', 'OUTPUT', '-p', 'tcp', '!', '-d', '172.16.0.0/12',
                                 '--dport', '443', '-j', 'MARK', '--set-mark', '443'])
 
+    subprocess_call(iptables + ['-A', 'OUTPUT', '-p', 'udp', '--dport', '123', '-j', 'MARK', '--set-mark', '443'])
+
     subprocess_call(['ip', 'rule', 'add', 'fwmark', '443', 'lookup', 'https'])
 
     subprocess_call(['ip', 'route', 'add', 'default', 'via', nat_gateways[subnet], 'table', 'https'])


### PR DESCRIPTION
if node is running in public subnet without public ip it can't sync time because ntp servers are not reachable.
For ntp traffic we will do the same trick as for https, i.e. send it via NAT-GW