### PR TITLE
Disable periodic apt updates

### DIFF
--- a/build/setup.d/11-remove-unneeded-packages.sh
+++ b/build/setup.d/11-remove-unneeded-packages.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+pkgs="
+popularity-contest
+update-notifier-common
+"
+
+echo "Removing packages..."
+
+apt-get remove -y -q --purge $pkgs

--- a/runtime/etc/apt/apt.conf.d/99-disable-periodic
+++ b/runtime/etc/apt/apt.conf.d/99-disable-periodic
@@ -1,0 +1,5 @@
+APT::Periodic::Enable "0";
+APT::Periodic::Update-Package-Lists "0";
+APT::Periodic::Download-Upgradeable-Packages "0";
+APT::Periodic::Unattended-Upgrade "0";
+APT::Periodic::AutocleanInterval "0";


### PR DESCRIPTION
As reported previously (#434), this can consume a lot of resources on small instances and cause the ASG to terminate instances. We don't need this, so let's just disable the corresponding cronjobs.

Additionally, stuff like `popularity-contest` should probably not run on our production instances, so let's remove that as well.

Fix #434, #439.