### PR TITLE
Remove shell options from remove-unattended-packages.sh

### DIFF
--- a/build/setup.d/11-remove-unneeded-packages.sh
+++ b/build/setup.d/11-remove-unneeded-packages.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-set -euo pipefail
-
 pkgs="
 popularity-contest
 update-notifier-common


### PR DESCRIPTION
The `setup.d` scripts are just sourced with `.`, not started normally. This means we shouldn't change options, otherwise we might break something else.