### PR TITLE
Update nvidia-driver to support Tesla Volta cards

### DIFF
--- a/build/setup.d/95-nvidia.sh
+++ b/build/setup.d/95-nvidia.sh
@@ -3,7 +3,7 @@
 # See https://github.com/NVIDIA/nvidia-docker/wiki/Deploy-on-Amazon-EC2
 # But we're using the run script to not depend on build tools
 DRIVER_ARCH="Linux-x86_64"
-DRIVER_VERSION="375.26"
+DRIVER_VERSION="384.81"
 DRIVER_FILENAME="NVIDIA-${DRIVER_ARCH}-${DRIVER_VERSION}.run"
 DRIVER_CHECKSUM="d60819b2e377398c7296999ab5e7c1a4"
 

--- a/build/setup.d/95-nvidia.sh
+++ b/build/setup.d/95-nvidia.sh
@@ -3,9 +3,9 @@
 # See https://github.com/NVIDIA/nvidia-docker/wiki/Deploy-on-Amazon-EC2
 # But we're using the run script to not depend on build tools
 DRIVER_ARCH="Linux-x86_64"
-DRIVER_VERSION="384.81"
+DRIVER_VERSION="384.90"
 DRIVER_FILENAME="NVIDIA-${DRIVER_ARCH}-${DRIVER_VERSION}.run"
-DRIVER_CHECKSUM="d60819b2e377398c7296999ab5e7c1a4"
+DRIVER_CHECKSUM="487f9702d76d9eebea5b73b33fe4d602"
 
 DOCKER_DRIVER_VERSION="1.0.1"
 DOCKER_DRIVER_FILENAME="nvidia-docker_${DOCKER_DRIVER_VERSION}-1_amd64.deb"


### PR DESCRIPTION
Version bump of nvidia-driver to 384.81 support Tesla V100 cards used in AWS p3 instances