### PR TITLE
Configuration parameter to disable taking process snapshots on Nodejs

### DIFF
--- a/runtime/opt/taupage/init.d/85-setup-appdynamics.sh
+++ b/runtime/opt/taupage/init.d/85-setup-appdynamics.sh
@@ -69,6 +69,9 @@ if [ -f "$nodejsSnippet" ]; then
 	if [ -n "$ACCESSKEY" ]; then
 		sed -i "s/accountAccessKey.*$/accountAccessKey:\ \'$ACCESSKEY\'\,/" $nodejsSnippet
 	fi
+        if [ "$NODEJS_SNAPSHOT" == "true" ]; then
+                sed -i "s/\"proxyAutolaunchDisabled\": true/\"proxyAutolaunchDisabled\": true,\n\"maxProcessSnapshotsPerPeriod\": 0/" $nodejsSnippet
+        fi
 fi
 
 

--- a/runtime/opt/taupage/init.d/85-setup-appdynamics.sh
+++ b/runtime/opt/taupage/init.d/85-setup-appdynamics.sh
@@ -11,6 +11,7 @@ ACCOUNT_GLOBALNAME=$config_appdynamics_account_globalname
 STACK_NAME=$config_notify_cfn_stack
 ENABLE_LOGGING=$config_appdynamics_enable_logging
 SCALYR_KEY=$config_scalyr_account_key
+NODEJS_SNAPSHOT=$config_nodejs_disable_snapshots
 
 # If KMS encrypted, decrypt KMS and save to ACCOUNTKEY variable
 if [[ $ACCESSKEY == "aws:kms:"* ]]; then


### PR DESCRIPTION
A memory leak issue was reported in NodeJs application agent for which appdynamics has suggested to reduce process snapshots to 0 explicitly in agent configuration. This pull request is raised to add a config parameter (NODEJS_SNAPSHOT=$config_nodejs_disable_snapshots) in senza yaml. 

Tested it locally in a stubbed environment and the code snippet updates the config.json properly.

Can we release the AMI to only monitoring-appdynamics account before releasing it to the effected team(s).