### PR TITLE
initramfs: add nvme support for booting on c5/m5 instances

### DIFF
--- a/build/setup.d/10-upgrade-base.sh
+++ b/build/setup.d/10-upgrade-base.sh
@@ -7,6 +7,8 @@ echo "Updating system..."
 # sudo rm -rf /var/lib/apt/lists/*
 apt-get update -y  # -q >>/tmp/build/upgrade.log
 
+echo "nvme" >> /etc/initramfs-tools/modules
+
 # install kernel headers and dkms
 apt-get install -y linux-headers-virtual-lts-xenial dkms
 


### PR DESCRIPTION
m5/c5 instances weren't supported because the rather old initramfs configuration we have didn't have the `nvme` module and m5/c5 use NVMe for the root volumes as well. Fix #482.