### PR TITLE
#489 allow enabling introspection for planb-tokeninfo service

### DIFF
--- a/build/setup.d/55-setup-taupage-yaml.sh
+++ b/build/setup.d/55-setup-taupage-yaml.sh
@@ -35,3 +35,6 @@ fi
 if [ -n "$TOKENINFO_BUSINESS_PARTNERS" ]; then
     echo "tokeninfo_business_partners: $TOKENINFO_BUSINESS_PARTNERS" >> /meta/taupage.yaml
 fi
+if [ -n "$TOKENINFO_ENABLE_INTROSPECTION" ]; then
+    echo "tokeninfo_enable_introspection: $TOKENINFO_ENABLE_INTROSPECTION" >> /meta/taupage.yaml
+fi

--- a/runtime/etc/init/planb-tokeninfo.conf
+++ b/runtime/etc/init/planb-tokeninfo.conf
@@ -14,5 +14,6 @@ script
         export OPENID_PROVIDER_CONFIGURATION_URL="$config_openid_provider_configuration_url"
         export REVOCATION_PROVIDER_URL="$config_revocation_provider_url"
         export BUSINESS_PARTNERS="$config_tokeninfo_business_partners"
+        export ENABLE_INTROSPECTION="$config_tokeninfo_enable_introspection"
         /opt/taupage/bin/planb-tokeninfo
 end script

--- a/runtime/etc/init/planb-tokeninfo.conf
+++ b/runtime/etc/init/planb-tokeninfo.conf
@@ -15,5 +15,9 @@ script
         export REVOCATION_PROVIDER_URL="$config_revocation_provider_url"
         export BUSINESS_PARTNERS="$config_tokeninfo_business_partners"
         export ENABLE_INTROSPECTION="$config_tokeninfo_enable_introspection"
+        if test -z "$ENABLE_INTROSPECTION"
+        then
+            export ENABLE_INTROSPECTION="False"
+        fi
         /opt/taupage/bin/planb-tokeninfo
 end script

--- a/runtime/etc/init/planb-tokeninfo.conf
+++ b/runtime/etc/init/planb-tokeninfo.conf
@@ -14,10 +14,8 @@ script
         export OPENID_PROVIDER_CONFIGURATION_URL="$config_openid_provider_configuration_url"
         export REVOCATION_PROVIDER_URL="$config_revocation_provider_url"
         export BUSINESS_PARTNERS="$config_tokeninfo_business_partners"
-        export ENABLE_INTROSPECTION="$config_tokeninfo_enable_introspection"
-        if test -z "$ENABLE_INTROSPECTION"
-        then
-            export ENABLE_INTROSPECTION="False"
+        if [ "$config_tokeninfo_introspection" = "true" ] || [ "$config_tokeninfo_introspection" = "True" ]; then
+                export ENABLE_INTROSPECTION="true"
         fi
         /opt/taupage/bin/planb-tokeninfo
 end script


### PR DESCRIPTION
Local planb-tokeninfo service takes into account ENABLE_INTROSPECTION environment variable. However currently there is no way for users to override it (taupage config variable doesn't get propagated to the startup script).