### PR TITLE
syslog: optionally add AWS metadata to the logs

### DIFF
--- a/runtime/opt/taupage/init.d/01-register-scalyr-agent.sh
+++ b/runtime/opt/taupage/init.d/01-register-scalyr-agent.sh
@@ -16,6 +16,12 @@ IMAGE=$(echo "$SOURCE" | awk -F \: '{ print $1 }')
 LOGPARSER=${config_scalyr_application_log_parser:-slf4j}
 CUSTOMLOG=$config_mount_custom_log
 CUSTOMPARSER=${config_scalyr_custom_log_parser:-slf4j}
+SYSLOGPARSER="systemLog"
+
+if [ -n "$config_rsyslog_aws_metadata" ];
+then
+    SYSLOGPARSER="systemLogMetadata"
+fi
 
 #check if appname and appversion is provided from the yaml
 if [ -z "$APPID" ] && [ -z "$APPVERSION" ];
@@ -79,7 +85,7 @@ fi
 #follow syslog
 echo "";
 echo -n "insert syslog to follow ... ";
-sed -i "/logs\:\ \[/a { path: \"/var/log/syslog\", \"copy_from_start\": true, attributes: {parser: \"systemLog\", application_id: \"$APPID\", application_version: \"$APPVERSION\", stack: \"$STACK\", source: \"$SOURCE\", image:\"$IMAGE\"} } " $scalyr_config
+sed -i "/logs\:\ \[/a { path: \"/var/log/syslog\", \"copy_from_start\": true, attributes: {parser: \"$SYSLOGPARSER\", application_id: \"$APPID\", application_version: \"$APPVERSION\", stack: \"$STACK\", source: \"$SOURCE\", image:\"$IMAGE\"} } " $scalyr_config
 if [ $? -eq 0 ];
 then
     echo -n "DONE";
@@ -92,7 +98,7 @@ fi
 #follow auth.log
 echo "";
 echo -n "insert authlog to follow ... ";
-sed -i "/logs\:\ \[/a { path: \"/var/log/auth.log\", \"copy_from_start\": true, attributes: {parser: \"systemLog\"} } " $scalyr_config
+sed -i "/logs\:\ \[/a { path: \"/var/log/auth.log\", \"copy_from_start\": true, attributes: {parser: \"$SYSLOGPARSER\"} } " $scalyr_config
 if [ $? -eq 0 ];
 then
     echo -n "DONE";

--- a/runtime/opt/taupage/init.d/04-configure-rsyslogd.sh
+++ b/runtime/opt/taupage/init.d/04-configure-rsyslogd.sh
@@ -3,10 +3,37 @@
 eval $(/opt/taupage/bin/parse-yaml.py /meta/taupage.yaml "config")
 
 rsyslog_max_message_size=$config_rsyslog_max_message_size
+rsyslog_aws_metadata=$config_rsyslog_aws_metadata
 rsyslog_config=/etc/rsyslog.conf
 
 if [[ -n "$rsyslog_max_message_size" ]]; then
     echo "setting rsyslog_max_message_size..."
     grep -q '^$MaxMessageSize' $rsyslog_config || sed -i "1s/^/\$MaxMessageSize ${rsyslog_max_message_size}\n/" $rsyslog_config
+fi
+
+if [[ -n "$rsyslog_aws_metadata" ]]; then
+    echo "enabling AWS metadata in rsyslog..."
+    IID="$(curl --fail -s http://169.254.169.254/latest/dynamic/instance-identity/document)"
+    if [ $? -eq 0 ]; then
+      AWS_ACCOUNT="$(echo "$IID" | jq -r .accountId)"
+      AWS_REGION="$(echo "$IID" | jq -r .region)"
+      cat >/etc/rsyslog.d/00-template.conf <<EOF
+template(name="DefaultFormat" type="list") {
+    property(name="timestamp" dateFormat="rfc3164")
+    constant(value=" $AWS_ACCOUNT $AWS_REGION ")
+    property(name="hostname")
+    constant(value=" ")
+    property(name="syslogtag")
+    property(name="msg" spifno1stsp="on" )
+    property(name="msg" droplastlf="on" )
+    constant(value="\n")
+}
+
+\$ActionFileDefaultTemplate DefaultFormat
+EOF
+    fi
+fi
+
+if [[ -n "$rsyslog_max_message_size" ]] || [[ -n "$rsyslog_aws_metadata" ]]; then
     service rsyslog restart
 fi


### PR DESCRIPTION
If `rsyslog_aws_metadata` is set in Taupage config, add AWS account ID and region to the log lines. This is useful for Scalyr S3 archival, because it only exports the raw log lines which means it's impossible to determine which account the message came from.