### PR TITLE
ntpd: enable iburst

### DIFF
--- a/runtime/etc/ntp.conf
+++ b/runtime/etc/ntp.conf
@@ -13,7 +13,7 @@ filegen clockstats file clockstats type day enable
 
 # Specify one or more NTP servers.
 # Use AWS Time Sync Service
-server 169.254.169.123
+server 169.254.169.123 prefer iburst
 
 # Access control configuration; see /usr/share/doc/ntp-doc/html/accopt.html for
 # details.  The web page <http://support.ntp.org/bin/view/Support/AccessRestrictions>


### PR DESCRIPTION
This leads to time being synced very quickly after boot instead of only after several minutes.