### PR TITLE
Don't send ntp traffic via NAT-GW

### DIFF
--- a/runtime/opt/taupage/init.d/00-create-custom-routing.py
+++ b/runtime/opt/taupage/init.d/00-create-custom-routing.py
@@ -66,8 +66,6 @@ def main():
     subprocess_call(iptables + ['-A', 'OUTPUT', '-p', 'tcp', '!', '-d', '172.16.0.0/12',
                                 '--dport', '443', '-j', 'MARK', '--set-mark', '443'])
 
-    subprocess_call(iptables + ['-A', 'OUTPUT', '-p', 'udp', '--dport', '123', '-j', 'MARK', '--set-mark', '443'])
-
     subprocess_call(['ip', 'rule', 'add', 'fwmark', '443', 'lookup', 'https'])
 
     subprocess_call(['ip', 'route', 'add', 'default', 'via', nat_gateways[subnet], 'table', 'https'])


### PR DESCRIPTION
Commit https://github.com/zalando-stups/taupage/commit/36907ee43133cc49d068efbad19737ab58a95077 introduced `AWS Time Sync Service` running on 169.254.169.123, which is ip of a hypervisor.
It broke DMZ deployments without public ip.