### PR TITLE
Implement trusted image validation

### DIFF
--- a/runtime/opt/taupage/runtime/Docker.py
+++ b/runtime/opt/taupage/runtime/Docker.py
@@ -39,7 +39,7 @@ def retry(name, max_tries=3, retry_delay=5):
                     return fn(*args, **kwargs)
                 except PermanentError:
                     raise
-                except Exception as e:
+                except Exception:
                     if attempt >= max_tries:
                         raise
                     else:

--- a/runtime/opt/taupage/runtime/Docker.py
+++ b/runtime/opt/taupage/runtime/Docker.py
@@ -7,7 +7,6 @@ import argparse
 import base64
 import boto.kms
 import boto.utils
-import codecs
 import functools
 import logging
 import pierone.api
@@ -332,7 +331,7 @@ def registry_login(config: dict, registry: str):
 @retry("verifying trusted image", max_tries=3, retry_delay=5)
 def image_trusted(registry, org, name, tag):
     if registry_requires_auth(registry):
-        headers = {"Authorization": "Basic {}".format(get_instance_identity_document())}
+        headers = {"Authorization": "Basic {}".format(pierone.api.iid_auth())}
     else:
         headers = {}
 
@@ -448,15 +447,6 @@ def parse_image_tag(source):
 
     registry, org, name = image_parts
     return registry, org, name, tag
-
-
-def get_instance_identity_document():
-    '''Gets the encoded IID'''
-
-    response = requests.get('http://169.254.169.254/latest/dynamic/instance-identity/pkcs7', timeout=30)
-    response.raise_for_status()
-    basic_auth = codecs.encode('instance-identity-document:{}'.format(response.text).encode('utf-8'), 'base64').strip()
-    return basic_auth.decode('utf-8').replace("\n", "")
 
 
 def main(args):

--- a/runtime/opt/taupage/runtime/Docker.py
+++ b/runtime/opt/taupage/runtime/Docker.py
@@ -7,6 +7,7 @@ import argparse
 import base64
 import boto.kms
 import boto.utils
+import codecs
 import functools
 import logging
 import pierone.api
@@ -318,12 +319,32 @@ def get_other_options(config: dict):
         yield '--shm-size={}'.format(config.get('shm_size'))
 
 
+def registry_requires_auth(registry: str):
+    return registry == 'pierone.stups.zalan.do'
+
+
 def registry_login(config: dict, registry: str):
-    if not registry_requires_auth(registry):
-        logging.warning("Docker registry doesn't seem to be private PierOne, skipping OAuth login")
-        return
-    pierone_url = 'https://{}'.format(registry)
-    pierone.api.docker_login_with_iid(pierone_url)
+    if registry_requires_auth(registry):
+        pierone_url = 'https://{}'.format(registry)
+        pierone.api.docker_login_with_iid(pierone_url)
+
+
+@retry("verifying trusted image", max_tries=3, retry_delay=5)
+def image_trusted(registry, org, name, tag):
+    if registry_requires_auth(registry):
+        headers = {"Authorization": "Basic {}".format(get_instance_identity_document())}
+    else:
+        headers = {}
+
+    url = "https://{}/v2/{}/{}/manifests/{}".format(registry, org, name, tag)
+    response = requests.get(url, headers=headers, timeout=30)
+    response.raise_for_status()
+    return response.headers.get("X-Trusted") == "true"
+
+
+def verify_image_trusted(registry, org, name, tag):
+    if not image_trusted(registry, org, name, tag):
+        raise ValueError("image is untrusted")
 
 
 @retry("Docker run", max_tries=3, retry_delay=5)
@@ -370,51 +391,72 @@ def wait_for_health_check(config: dict):
     sys.exit(2)
 
 
-def is_valid_source(source):
-    '''
-    >>> is_valid_source('')
-    False
+def parse_image_tag(source):
+    '''Parse a docker tag into image, org, name, tag, throwing an error if any of the components are missing.
 
-    >>> is_valid_source('foo/bar')
-    False
+    >>> parse_image_tag('')
+    Traceback (most recent call last):
+    ...
+    ValueError: Image tag not specified
 
-    >>> is_valid_source('foo/bar:latest')
-    False
+    >>> parse_image_tag('nginx:1.2.3')
+    Traceback (most recent call last):
+    ...
+    ValueError: No registry specified or invalid image name: nginx
 
-    >>> is_valid_source('foo/bar:1.0-SNAPSHOT')
-    False
+    >>> parse_image_tag('foo/nginx:1.2.3')
+    Traceback (most recent call last):
+    ...
+    ValueError: No registry specified or invalid image name: foo/nginx
 
-    >>> is_valid_source('foo/bar:1.0')
-    True
-    '''
-    parts = source.rsplit(':', 1)
-    if len(parts) != 2:
-        # missing tag
-        return False
-    _, tag = parts
-    if tag == 'latest':
-        # mutable "latest" images are not allowed
-        return False
-    elif 'SNAPSHOT' in tag:
-        # mutable *-SNAPSHOT images are not allowed
-        return False
-    return True
+    >>> parse_image_tag('registry.example.org/foo/nginx')
+    Traceback (most recent call last):
+    ...
+    ValueError: Image tag not specified
+
+    >>> parse_image_tag('registry.example.org/foo/nginx:')
+    Traceback (most recent call last):
+    ...
+    ValueError: Image tag not specified
+
+    >>> parse_image_tag('registry.example.org/foo/nginx:latest')
+    Traceback (most recent call last):
+    ...
+    ValueError: latest and snapshot tags are non-compliant
+
+    >>> parse_image_tag('registry.example.org/foo/nginx:foo-SNAPSHOT')
+    Traceback (most recent call last):
+    ...
+    ValueError: latest and snapshot tags are non-compliant
+
+    >>> parse_image_tag('registry.example.org/foo/nginx:1.2.3')
+    ('registry.example.org', 'foo', 'nginx', '1.2.3')
+'''
+    if ":" not in source:
+        raise ValueError("Image tag not specified")
+
+    image, tag = source.split(":", 1)
+    if tag == "":
+        raise ValueError("Image tag not specified")
+
+    if tag == "latest" or "SNAPSHOT" in tag:
+        raise ValueError("latest and snapshot tags are non-compliant".format(tag))
+
+    image_parts = image.split("/", 2)
+    if len(image_parts) != 3:
+        raise ValueError("No registry specified or invalid image name: {}".format(image))
+
+    registry, org, name = image_parts
+    return registry, org, name, tag
 
 
-def registry_requires_auth(registry: str):
-    return registry == 'pierone.stups.zalan.do'
+def get_instance_identity_document():
+    '''Gets the encoded IID'''
 
-
-def registry_supports_trusted_images(registry: str):
-    return registry == 'pierone.stups.zalan.do' or registry == 'registry.opensource.zalan.do'
-
-
-def is_image_trusted(image):
-    if not registry_supports_trusted_images(image.registry):
-        logging.warning("Docker registry doesn't seem to be PierOne, skipping Trusted header check")
-        return False
-    image_details = pierone.api.get_image_tag(image)
-    return image_details is not None and image_details['trusted']
+    response = requests.get('http://169.254.169.254/latest/dynamic/instance-identity/pkcs7', timeout=30)
+    response.raise_for_status()
+    basic_auth = codecs.encode('instance-identity-document:{}'.format(response.text).encode('utf-8'), 'base64').strip()
+    return basic_auth.decode('utf-8').replace("\n", "")
 
 
 def main(args):
@@ -424,13 +466,9 @@ def main(args):
     source = config['source']
 
     try:
-        image = pierone.api.DockerImage.parse(source)
+        registry, org, name, tag = parse_image_tag(source)
     except ValueError as e:
-        logging.error('Error parsing Docker image: %s', e)
-        sys.exit(1)
-
-    if not is_valid_source(source):
-        logging.error('Invalid source Docker image: %s', source)
+        logging.error('Invalid source Docker image: %s', e)
         sys.exit(1)
 
     docker_cmd = get_docker_command(config)
@@ -454,16 +492,17 @@ def main(args):
             logging.error('Docker start of existing container failed: %s', str(e))
             sys.exit(1)
     else:
-        registry_login(config, image.registry)
-
-        if not is_image_trusted(image):
-            logging.error('Image is not trusted: %s', image)
+        registry_login(config, registry)
+        try:
+            verify_image_trusted(registry, org, name, tag)
+        except Exception as e:
+            logging.error("Trusted image check failed: %s", e)
             sys.exit(1)
 
         cmd = [docker_cmd, 'run', '-d', '--log-driver=syslog', '--name=taupageapp', '--restart=on-failure:10']
         for f in get_env_options, get_volume_options, get_port_options, get_other_options:
             cmd += list(f(config))
-        cmd += [str(image)]
+        cmd += [source]
 
         secret_envs = get_secret_envs(config)
 

--- a/runtime/opt/taupage/runtime/Docker.py
+++ b/runtime/opt/taupage/runtime/Docker.py
@@ -346,7 +346,8 @@ def verify_image_trusted(registry, org, name, tag):
     response = requests.get(url, headers=headers, timeout=30)
     response.raise_for_status()
 
-    if response.headers.get("X-Production-Ready-Taupage") == "true" or response.headers.get("X-Trusted") == "true":
+    ready = response.headers.get("X-Production-Ready-Taupage") or response.headers.get("X-Trusted")
+    if ready == "true":
         return
 
     message = response.headers.get("X-Production-Ready-Reason") or "image is untrusted"


### PR DESCRIPTION
This changes the way how the `Trusted` information for a particular image is retrieved.

It uses the original approach implemented [here](https://github.com/zalando-stups/taupage/pull/502/commits/0d9bee811c77ad36a91ae64b86258b4bf9b781fa) ~~and adds the missing `pierone.api.iid_auth()` part via `get_instance_identity_document()`~~.

The main difference to https://github.com/zalando-stups/taupage/pull/504 is that there's a dedicated request and response-processing logic for the `Trusted` header. This avoids any changes in pierone's api client library.

/cc @mikkeloscar @aermakov-zalando 