### PR TITLE
Remove bracket

### DIFF
--- a/tests/spec/localhost/td-agent_spec.rb
+++ b/tests/spec/localhost/td-agent_spec.rb
@@ -22,7 +22,7 @@ end
 # Ensure that /var/log/application.log is readable (chmod 644
 describe file('/var/log/application.log') do
   it { should be_mode 644 }
-end)
+end
 
 # Check if Scalyr output plugin is installed
 describe command('td-agent-gem list') do


### PR DESCRIPTION
This fixes a syntax error:

```
14:22:37.745 
14:22:37.745 An error occurred while loading ./spec/localhost/td-agent_spec.rb.
14:22:37.745 On host `localhost'
14:22:37.745 Failure/Error: __send__(method, file)
14:22:37.745 SyntaxError:
14:22:37.745   /tmp/tests/spec/localhost/td-agent_spec.rb:25: syntax error, unexpected ')', expecting end-of-input
```

Signed-off-by: Felix Mueller <felix.mueller@zalando.de>