### PR TITLE
Adding dummy Scalyr Key for test

### DIFF
--- a/test-userdata.yaml
+++ b/test-userdata.yaml
@@ -83,4 +83,4 @@ sysfs:
   /sys/kernel/mm/transparent_hugepage/enabled: never
 
 # Dummy Scalyr key
-scalyr_account_key: 123
+scalyr_account_key: foo1234

--- a/test-userdata.yaml
+++ b/test-userdata.yaml
@@ -81,3 +81,6 @@ sysctl:
 # Edit sysfs paths
 sysfs:
   /sys/kernel/mm/transparent_hugepage/enabled: never
+
+# Dummy Scalyr key
+scalyr_account_key: 123


### PR DESCRIPTION
In order to properly test https://github.com/zalando-stups/taupage/blob/master/tests/spec/localhost/scalyr-agent_spec.rb a (dummy) key actually needs to be configured.

Signed-off-by: Felix Mueller <felix.mueller@zalando.de>