### PR TITLE
Fix the function call when docker start fails

### DIFF
--- a/runtime/opt/taupage/runtime/Docker.py
+++ b/runtime/opt/taupage/runtime/Docker.py
@@ -516,7 +516,7 @@ def main(args):
         try:
             run_docker(cmd, args.dry_run)
         except Exception as e:
-            logging.error('Docker run failed: %s', mask_command(str(e).split(' ')))
+            logging.error('Docker run failed: %s', mask_command(str(e).split(' '), secret_envs))
             sys.exit(1)
 
     wait_for_health_check(config)


### PR DESCRIPTION
The #519 change added masking of all KMS encrypted values. But the error message which prints the command was not updated to use the updated function, which causes and exception. This PR fixes the issue.