### PR TITLE
Reduce rsyslogd output

### DIFF
--- a/runtime/opt/taupage/init.d/01-register-scalyr-agent.sh
+++ b/runtime/opt/taupage/init.d/01-register-scalyr-agent.sh
@@ -11,6 +11,8 @@ STACK=$config_notify_cfn_stack
 IMAGE=$(echo "$SOURCE" | awk -F \: '{ print $1 }')
 AWS_ACCOUNT=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq --raw-output .accountId)
 AWS_REGION=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq --raw-output .region)
+AWS_EC2_INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+AWS_EC2_HOSTNAME=$(curl -s http://169.254.169.254/latest/meta-data/hostname)
 CUSTOMLOG=$config_mount_custom_log
 #set Scalyr Variables
 if [ $(set -o posix;set|grep -c config_logging_) -eq 0 ];
@@ -108,7 +110,7 @@ scalyr_config=/etc/scalyr-agent-2/agent.json
 
 #set serverhost to application_id
 echo -n "set app name and version... ";
-sed -i "/\/\/ serverHost: \"REPLACE THIS\"/s@.*@  serverHost:\ \"$APPID\", application_id: \"$APPID\", application_version: \"$APPVERSION\", stack: \"$STACK\", source: \"$SOURCE\", image:\"$IMAGE\", aws_account:\"$AWS_ACCOUNT\", aws_region:\"$AWS_REGION\"@" $scalyr_config
+sed -i "/\/\/ serverHost: \"REPLACE THIS\"/s@.*@  serverHost:\ \"$APPID\", application_id: \"$APPID\", application_version: \"$APPVERSION\", stack: \"$STACK\", source: \"$SOURCE\", image:\"$IMAGE\", aws_account:\"$AWS_ACCOUNT\", aws_region:\"$AWS_REGION\", aws_ec2_instance_id:\"$AWS_EC2_INSTANCE_ID\", aws_ec2_hostname:\"$AWS_EC2_HOSTNAME\"@" $scalyr_config
 if [ $? -eq 0 ];
 then
     echo "DONE"

--- a/runtime/opt/taupage/init.d/04-configure-rsyslogd.sh
+++ b/runtime/opt/taupage/init.d/04-configure-rsyslogd.sh
@@ -48,7 +48,7 @@ EOF
   need_rsyslog_restart='y'
 fi
 
-if [[ "$rsyslog_application_log_format" == "legacy"]]; then
+if [[ "$rsyslog_application_log_format" == "legacy" ]]; then
   cat >/etc/rsyslog.d/24-application.conf <<EOF
 :syslogtag, startswith, "docker" /var/log/application.log
 & ~

--- a/runtime/opt/taupage/init.d/04-configure-rsyslogd.sh
+++ b/runtime/opt/taupage/init.d/04-configure-rsyslogd.sh
@@ -39,7 +39,22 @@ EOF
     fi
 fi
 
-if [[ -n "$rsyslog_application_log_format" ]]; then
+if [[ ! -n "$rsyslog_application_log_format" ]]; then
+  cat >/etc/rsyslog.d/24-application.conf <<EOF
+\$template customApplicationLogFormat,"%msg%\\n"
+:syslogtag, startswith, "docker" /var/log/application.log; customApplicationLogFormat
+& ~
+EOF
+  need_rsyslog_restart='y'
+fi
+
+if [[ "$rsyslog_application_log_format" == "legacy"]]; then
+  cat >/etc/rsyslog.d/24-application.conf <<EOF
+:syslogtag, startswith, "docker" /var/log/application.log
+& ~
+EOF
+  need_rsyslog_restart='y'
+elif [[ -n "$rsyslog_application_log_format" ]]; then
   cat >/etc/rsyslog.d/24-application.conf <<EOF
 \$template customApplicationLogFormat,"$rsyslog_application_log_format"
 :syslogtag, startswith, "docker" /var/log/application.log; customApplicationLogFormat


### PR DESCRIPTION
This Pull-Request by default reduces redundant log output by default which is logged by application logging libraries anyways such as the date.
It also removes the Docker container ID and instance hostname and moves both over to the Scalyr server fields.