### PR TITLE
Mask JWT tokens for logs send by Scalyr Agent

### DIFF
--- a/runtime/opt/taupage/init.d/01-register-scalyr-agent.sh
+++ b/runtime/opt/taupage/init.d/01-register-scalyr-agent.sh
@@ -174,7 +174,9 @@ if [ "$USE_SCALYR_AGENT_APPLOG" = "True" ]
 then
   echo -n "insert application to follow... ";
   sed -i "/logs\:\ \[/a { path: \"/var/log/application.log\", \"copy_from_start\": true, attributes: {parser: \"$LOGPARSER\"}, \
-  sampling_rules: $SCALYR_AGENT_APPLOG_SAMPLING } " $scalyr_config
+  sampling_rules: $SCALYR_AGENT_APPLOG_SAMPLING, \
+  redaction_rules: [{\"match_expression\": \"eyJ[a-zA-Z0-9/+_=-]{5,}\\.eyJ[a-zA-Z0-9/+_=-]{5,}\\.[a-zA-Z0-9/+_=-]{5,}\", \
+  \"replacement\": \"+++JWT_TOKEN_REDACTED+++\"}]}" $scalyr_config
   if [ $? -eq 0 ];
   then
       echo "DONE"


### PR DESCRIPTION
Any strings matching the format of a [JWT](https://tools.ietf.org/html/rfc7519) are replaced with `+++JWT_TOKEN_REDACTED+++` before they are shipped Scalyr.