### PR TITLE
Set THP to madvise in grub

### DIFF
--- a/build/setup.d/07-disable-thp.sh
+++ b/build/setup.d/07-disable-thp.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -x
+
+sed -i -E "s/^GRUB_CMDLINE_LINUX_DEFAULT=\"(.*)\"$/GRUB_CMDLINE_LINUX_DEFAULT=\"transparent_hugepage=madvise \1\"/" /etc/default/grub
+
+update-grub


### PR DESCRIPTION
Set the THP to madvise to prevent overconsumption of memory in jobs with many forked processes.