### PR TITLE
Specifying role in cfn-signal command

### DIFF
--- a/runtime/opt/taupage/init.sh
+++ b/runtime/opt/taupage/init.sh
@@ -80,7 +80,7 @@ else
     echo "INFO: Notifying CloudFormation (region: $EC2_REGION, stack: $config_notify_cfn_stack, resource: $config_notify_cfn_resource, status: $result, IAM Role: $IAM_ROLE)..."
 
     ## First tries signal command with the role specified, and if that fails executes the signal command without the role
-    cfn-signal -e $result --role $IAM_ROLE --stack $config_notify_cfn_stack --resource $config_notify_cfn_resource --region $EC2_REGION || cfn-signal -e $result --stack $config_notify_cfn_stack --resource $config_notify_cfn_resource --region $EC2_REGION
+    cfn-signal -e "$result" --role "$IAM_ROLE" --stack "$config_notify_cfn_stack" --resource "$config_notify_cfn_resource" --region "$EC2_REGION" || cfn-signal -e "$result" --stack "$config_notify_cfn_stack" --resource "$config_notify_cfn_resource" --region "$EC2_REGION"
 fi
 
 END_TIME=$(date +"%s")

--- a/runtime/opt/taupage/init.sh
+++ b/runtime/opt/taupage/init.sh
@@ -75,9 +75,12 @@ else
     EC2_AVAIL_ZONE=$( curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone )
     EC2_REGION="`echo \"$EC2_AVAIL_ZONE\" | sed -e 's:\([0-9][0-9]*\)[a-z]*\$:\\1:'`"
 
-    echo "INFO: Notifying CloudFormation (region: $EC2_REGION, stack: $config_notify_cfn_stack, resource: $config_notify_cfn_resource, status: $result)..."
+    IAM_ROLE=$( curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials )
 
-    cfn-signal -e $result --stack $config_notify_cfn_stack --resource $config_notify_cfn_resource --region $EC2_REGION
+    echo "INFO: Notifying CloudFormation (region: $EC2_REGION, stack: $config_notify_cfn_stack, resource: $config_notify_cfn_resource, status: $result, IAM Role: $IAM_ROLE)..."
+
+    ## First tries signal command with the role specified, and if that fails executes the signal command without the role
+    cfn-signal -e $result --role $IAM_ROLE --stack $config_notify_cfn_stack --resource $config_notify_cfn_resource --region $EC2_REGION || cfn-signal -e $result --stack $config_notify_cfn_stack --resource $config_notify_cfn_resource --region $EC2_REGION
 fi
 
 END_TIME=$(date +"%s")


### PR DESCRIPTION
To prevent situations where the `cfn-signal` command fails on init when the call is done across stacks, the role is specified when executing `cfn-signal`.
The role that is used with the command needs to have the following policy attached:
```
{
        "Version": "2012-10-17",
        "Statement": [
            {
                "Effect": "Allow",
                "Action": [
                    "cloudformation:SignalResource",
                    "cloudformation:DescribeStackResource"
                ],
                "Resource": "*"
            }
        ]
    }
```