### PR TITLE
Use the old interface naming scheme

### DIFF
--- a/build/setup.d/07-disable-thp.sh
+++ b/build/setup.d/07-disable-thp.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-set -x
-
-echo 'GRUB_CMDLINE_LINUX_DEFAULT="transparent_hugepage=madvise $GRUB_CMDLINE_LINUX_DEFAULT"' > /etc/default/grub.d/99-disable-thp.cfg
-
-update-grub

--- a/build/setup.d/07-grub-settings.sh
+++ b/build/setup.d/07-grub-settings.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -x
+
+echo 'GRUB_CMDLINE_LINUX_DEFAULT="transparent_hugepage=madvise net.ifnames=0 biosdevname=0 $GRUB_CMDLINE_LINUX_DEFAULT"' > /etc/default/grub.d/99-taupage.cfg
+
+update-grub


### PR DESCRIPTION
This changes back to the old interface naming scheme (`eth*`) since some teams are relying on it.