### PR TITLE
Fixing misleading character

### DIFF
--- a/runtime/opt/taupage/init.sh
+++ b/runtime/opt/taupage/init.sh
@@ -80,7 +80,7 @@ else
     echo "INFO: Notifying CloudFormation (region: $EC2_REGION, stack: $config_notify_cfn_stack, resource: $config_notify_cfn_resource, status: $result, IAM Role: $IAM_ROLE)..."
 
     ## First tries signal command with the role specified, and if that fails executes the signal command without the role
-    cfn-signal -e "$result" --role "$IAM_ROLE" --stack "$config_notify_cfn_stack" --resource "$config_notify_cfn_resource" --region "$EC2_REGION" || cfn-signal -e "$result" --stack "$config_notify_cfn_stack" --resource "$config_notify_cfn_resource" --region "$EC2_REGION"
+    cfn-signal -e "$result" --role "$IAM_ROLE" --stack "$config_notify_cfn_stack" --resource "$config_notify_cfn_resource" --region "$EC2_REGION" || cfn-signal -e "$result" --stack "$config_notify_cfn_stack" --resource "$config_notify_cfn_resource" --region "$EC2_REGION"
 fi
 
 END_TIME=$(date +"%s")


### PR DESCRIPTION
> If it looks like a space, but it breaks your script, it is not a space.

In line 83, when the second operand of the OR operation is executed, the script fails with the following error message:
`taupage-init: /opt/taupage/init.sh: 83: /opt/taupage/init.sh:  cfn-signal: not found`

After multiple experiments, and hints from hard earned experienced, we identified a character in the second command that, despite every editor representing it as a blank space, it really isn't.
It is `0xc2a0` which in UTF-8 means a `NO-BREAK SPACE`.

Ref: http://www.fileformat.info/info/unicode/char/00a0/index.htm
