### PR TITLE
share-ami.sh: fix -u failing

### DIFF
--- a/share-ami.sh
+++ b/share-ami.sh
@@ -66,7 +66,7 @@ for target_rgn in $copy_regions; do
     share_ami $target_rgn
 done
 
-if [[ -z "${NO_RELEASE_TAG}" ]]; then
+if [[ "${NO_RELEASE_TAG:-}" ]]; then
     # git add new release tag
     git tag $ami_name
     git push --tags


### PR DESCRIPTION
`-u` means we can't use `-z $FOO`.