### PR TITLE
remove copytruncate from logrotate

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,4 @@ See the [STUPS documentation](https://docs.stups.io/en/latest/installation/taupa
     * **setup.d/** (all setup scripts that get executed on the server)
 * **/runtime/** (everything, that has to be present during runtime)
 * **/tests/** (contains various tests, such as python, serverspec and shell script tests)
+

--- a/runtime/etc/logrotate.d/application
+++ b/runtime/etc/logrotate.d/application
@@ -5,7 +5,6 @@
         size 256M
         missingok
         notifempty
-        copytruncate
         compress
         delaycompress
         sharedscripts

--- a/runtime/etc/logrotate.d/application
+++ b/runtime/etc/logrotate.d/application
@@ -10,7 +10,5 @@
         sharedscripts
         postrotate
                 reload rsyslog >/dev/null 2>&1 || true
-                /usr/sbin/scalyr-agent-2 stop 
-                /usr/sbin/scalyr-agent-2 start
         endscript
 }


### PR DESCRIPTION
In order to not lose any logs during rotation
