### PR TITLE
Correctly handle volume mappings on NVME-based instances

### DIFF
--- a/build/setup.d/20-install-packages.sh
+++ b/build/setup.d/20-install-packages.sh
@@ -20,6 +20,7 @@ libswitch-perl
 libwww-perl
 libyaml-dev
 libyaml-0-2
+nvme-cli
 mdadm
 ntp
 openjdk-8-jre-headless

--- a/runtime/etc/udev/rules.d/999-aws-ebs-nvme.rules
+++ b/runtime/etc/udev/rules.d/999-aws-ebs-nvme.rules
@@ -1,0 +1,1 @@
+ACTION=="add", SUBSYSTEM=="block", KERNEL=="nvme[1-26]n1", ATTRS{model}=="Amazon Elastic Block Store              ", RUN+="/usr/local/bin/ebs-nvme-mapping"

--- a/runtime/usr/local/bin/ebs-nvme-mapping
+++ b/runtime/usr/local/bin/ebs-nvme-mapping
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+PATH="${PATH}:/usr/sbin"
+
+for blkdev in $( nvme list | awk '/^\/dev/ { print $1 }' ) ; do
+  mapping=$(nvme id-ctrl --raw-binary "${blkdev}" | cut -c3073-3104 | tr -s ' ' | sed 's/ $//g')
+  if [[ "${mapping}" == /dev/* ]]; then
+    if [[ ! ( -b ${blkdev} && -L ${mapping} ) ]]; then
+      ln -s "${blkdev}" "${mapping}"
+    fi
+  fi
+done


### PR DESCRIPTION
Use the scripts from [this repo](https://github.com/oogali/ebs-automatic-nvme-mapping) to correctly handle both old and new generation instances.