### PR TITLE
Run the setup.d scripts in separate shells

### DIFF
--- a/build/setup.sh
+++ b/build/setup.sh
@@ -14,5 +14,5 @@ cd $(dirname $0)
 export BUILD_DIR=$(pwd)
 for script in $(ls setup.d | sort); do
     cd $BUILD_DIR
-    . setup.d/$script
+    bash -e setup.d/$script
 done


### PR DESCRIPTION
Turns out the build scripts all run in the same shell for whatever reason. Adding a `set -euo pipefail` in the OPA install script broke some other scripts. Let's try fixing this mess.