### PR TITLE
install-cloudwatch-logs-agent: update pip first

### DIFF
--- a/build/setup.d/71-install-cloudwatch-logs-agent.sh
+++ b/build/setup.d/71-install-cloudwatch-logs-agent.sh
@@ -6,6 +6,8 @@ cd /tmp/cw-logs-setup
 # put empty config file as placeholder for the real config file
 touch cloudwatch_logs_empty.conf
 
+pip install --upgrade pip
+
 # download and install latest version of the cloudwatch logs agent
 wget https://s3.amazonaws.com/aws-cloudwatch/downloads/1.3.9/awslogs-agent-setup.py
 chmod +x ./awslogs-agent-setup.py


### PR DESCRIPTION
It looks like the ancient `pip` we have right now grabs broken versions of some of the dependencies, let's update it.